### PR TITLE
Move Google Analytics tracking ID to environment variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install, build, and upload your site
         uses: withastro/action@v3
+        env:
+          GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
         # with:
           # path: . # The root location of your Astro project inside the repository. (optional)
           # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -109,14 +109,18 @@ const socialImageURL = new URL(
     <!-- <ViewTransitions /> -->
 
     <!-- Google tag (gtag.js) -->
-    <script type="text/partytown" async src="https://www.googletagmanager.com/gtag/js?id=G-JCR2S41KRX"></script>
-    <script type="text/partytown">
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+    {import.meta.env.GA_TRACKING_ID && (
+      <>
+        <script type="text/partytown" async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.GA_TRACKING_ID}`}></script>
+        <script type="text/partytown" define:vars={{ gaId: import.meta.env.GA_TRACKING_ID }}>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
 
-      gtag('config', 'G-JCR2S41KRX');
-    </script>
+          gtag('config', gaId);
+        </script>
+      </>
+    )}
 
     <script is:inline src="/toggle-theme.js"></script>
   </head>


### PR DESCRIPTION
## What this PR does

Moves the hardcoded Google Analytics tracking ID to an environment variable configuration, making it configurable through GitHub secrets and enabling conditional loading.

## Why it's needed

This change improves security by removing hardcoded tracking IDs from the codebase and allows for different tracking configurations across environments (development, staging, production). The analytics script now only loads when the GA_TRACKING_ID environment variable is present.

Changes include:
- Updated GitHub Actions workflow to pass GA_TRACKING_ID from secrets
- Modified Layout.astro to use environment variable and conditionally render GA scripts
- Analytics now only loads when tracking ID is configured