### PR TITLE
feat: update Agentic RAG course schedule to March 11

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
         <p><strong>Take my courses on O'Reilly:</strong></p>
         <ul>
           <li><a href="https://learning.oreilly.com/course/building-ai-agents/0642572077884/" target="_blank" rel="noopener noreferrer">Building AI Agents with LangGraph</a> (on-demand course)</li>
-          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, new date to be scheduled soon)</li>
+          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, March 11, 8pm-Midnight Singapore Standard Time)</li>
           <li><a href="https://learning.oreilly.com/live-events/getting-started-with-claude-agent-sdk/0642572273255/0642572273248/" target="_blank" rel="noopener noreferrer">Getting Started with Claude Agent SDK</a> (live course, February 24 at 9pm SGT / 8am ET)</li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary

Updates the Agentic RAG with LangGraph course schedule on the homepage.

## Changes

- Updated course time to: **March 11, 8pm-Midnight Singapore Standard Time**
- Replaced "new date to be scheduled soon" with the confirmed schedule