### PR TITLE
Add OpenClaw personal assistant blog post

### DIFF
--- a/src/content/blog/openclaw-experiments.md
+++ b/src/content/blog/openclaw-experiments.md
@@ -1,7 +1,7 @@
 ---
 title: "A Week with OpenClaw as My Personal Assistant"
 author: "Sajal Sharma"
-pubDatetime: 2026-02-15T00:00:00Z
+pubDatetime: 2026-02-16T00:00:00Z
 slug: openclaw-experiments
 featured: true
 draft: false
@@ -41,6 +41,7 @@ For file access, I don't share anything from my personal computer. I created a s
 I also set up Gmail as a secondary channel so I can forward emails to James for processing. This one required more careful engineering though. I don't want anyone other than me sending emails to James - after all, it's my personal assistant. I implemented a deterministic hook that filters incoming emails against an approved sender list - so anything from unapproved email accounts is ignored. When I asked James to implement this filter itself, it chose an LLM based filtering mechanism, and we learned pretty quickly that it won't work.
 
 ![James processing an email to create tasks, schedule calendar events, and save articles](@assets/images/blog/openclaw-experiments/email.png)
+_James autonomously processing an email: extracting tasks for Things, scheduling calendar events, and saving articles to my knowledge base_
 
 I set up Tailscale to access the Mac Mini when I'm not nearby to debug it (which I've needed to use **a lot**).
 
@@ -70,7 +71,7 @@ James tracks my programs, logs progress, and checks my calendar for scheduled wo
 
 I'm thinking about adding more workflows in the coming weeks for things like:
 
-**Apartment hunting:** Tracking listings, comparing neighborhoods, monitoring prices, reminding me to follow up—all the tedious tracking work that's perfect for an AI assistant.
+**Apartment hunting:** Tracking listings, comparing neighborhoods, monitoring prices, reminding me to follow up. All the tedious tracking work that's perfect for an AI assistant.
 
 **Career Opportunity Tracking:** Monitoring opportunities that align with my experience and aspirations, identifying networking events etc.
 
@@ -78,7 +79,7 @@ And more may emerge as time goes on!
 
 ## Does It Actually Work? Or is it just hype?
 
-Honest answer: it's complicated. There are really two questions here—does it work at a technical level, and does it provide value? The answer to both, one week in, is still unclear.
+Honest answer: it's complicated. There are really two questions here: does it work at a technical level, and does it provide value? The answer to both, one week in, is still unclear.
 
 ### Does it work technically?
 
@@ -108,6 +109,51 @@ I'm betting the use cases will grow over time. Right now I have five workflows. 
 
 But for me it's the joy of experimenting with it. Building a system that can perhaps replace my app subscriptions while also being personalized for the things that I care about is genuinely exciting. I don't plan to let the bot join Moltbook or write hit pieces when its PR is rejected on Github. I'm content with letting it be my personal assistant, not some AGI experiment.
 
-The automation also feels personal in a way that generic productivity tools don't. The contextualization is what gives it value—even if it's hard to quantify. It beats managing my personal ChatGPT subscription with a personal Claude subscription and a work Claude subscription etc—each with access to their own projects and folders and mish-mash of contexts.
+The automation also feels personal in a way that generic productivity tools don't. The contextualization is what gives it value, even if it's hard to quantify. It beats managing my personal ChatGPT subscription with a personal Claude subscription and a work Claude subscription etc., each with access to their own projects and folders and mish-mash of contexts.
 
-Overall I'm cautiously optimistic, and excited about implementing more automations!
+## What This Means for the Future of Agents
+
+After just one week with OpenClaw, I get the hype. This isn't just about having a personal assistant. It's a glimpse into where the entire AI agent ecosystem is heading.
+
+### Omnipresent Agents Are the Future
+
+The most striking thing about OpenClaw is that it meets me where I already am. I don't need to open a specific app or be at my desk. It's in Telegram, it's in my email, it could be in Slack or WhatsApp or whatever else I use. This omnipresence matters more than I initially realized.
+
+People don't want another app to check. They want agents that integrate into their existing communication flows. The power isn't in the agent itself, but in being accessible wherever you naturally spend your time.
+
+### Hyper-Contextualized Agents Win
+
+Generic ChatGPT or Claude with a folder of documents uploaded just doesn't cut it for real productivity work. The value comes from deep integration: agents that can actually access your apps, read your calendar, check your todos, understand your knowledge base, and most importantly, take actions on your behalf.
+
+This is the same insight that makes Claude Code so powerful for developers. Claude Code doesn't just answer questions about your codebase. It operates on it. It reads files, writes code, runs tests, creates commits. OpenClaw is the same concept extended to personal productivity systems. Instead of a chatbot with context, you get an agent with agency.
+
+### Big Tech Is Moving Fast
+
+The timing here is telling. Just yesterday, [Peter Steinberger, OpenClaw's creator, announced he's joining OpenAI](https://techcrunch.com/2026/02/15/openclaw-creator-peter-steinberger-joins-openai/). This signals that the major AI companies recognize this space is critical and are moving aggressively to capture it.
+
+Look at what's happening:
+
+- Meta has Manus, their own take on AI agents
+- Anthropic has Claude Code for developers and CoWork for workplace collaboration
+- OpenAI is clearly investing in this direction with the Steinberger hire
+
+The pattern is clear: foundation model companies aren't satisfied just providing APIs. They want to own the agent layer that sits on top of their models and integrates into users' daily workflows.
+
+### This Is the Next Logical Step
+
+It feels inevitable when you think about it. We went from:
+
+1. Chat interfaces that answer questions →
+2. Chat interfaces with memory and projects →
+3. Agents that can call tools and APIs →
+4. Integrated agents that proactively act on your behalf
+
+OpenClaw and similar frameworks represent step 4. They're moving AI from reactive to proactive, from stateless conversations to persistent, contextualized assistants that understand your systems and can operate within them autonomously.
+
+What surprises me most is how conspicuously absent Apple seems from this space. They have all the advantages: complete control over their ecosystem, native on-device AI without relying on external API calls, Siri already on every device, AppleScript and Shortcuts for app automation. They could build this integration far more seamlessly than anyone else. And yet, despite all these structural advantages, they seem far behind. Maybe Apple Intelligence will evolve into something like this, but right now it feels like they're missing a massive opportunity while open-source projects and AI startups are defining what personal AI assistants should be.
+
+---
+
+So where does this leave me and my experiments with James? Cautiously optimistic. The technology clearly works, even if it requires tinkering. The workflows are already providing value, even if that value is hard to quantify. And the trajectory of where this is all heading (omnipresent, deeply contextualized agents that understand and operate within our personal systems) feels both inevitable and genuinely exciting.
+
+For now, I'm going to keep experimenting, keep building new workflows, and keep learning what it means to have a truly personal AI assistant. The future is coming fast, and it's fascinating to be building it one automation at a time.


### PR DESCRIPTION
## Summary

New blog post exploring one week of experiments with OpenClaw as a personal AI assistant, including:

- Setup and architecture (Mac Mini, Telegram, Gmail integration)
- Workflows implemented (daily briefings, weekly reviews, fitness tracking, studying)
- Technical challenges and lessons learned
- Value assessment and ROI considerations
- Future implications for AI agent ecosystem

The post also analyzes broader industry trends:
- Demand for omnipresent agents across communication channels
- Why hyper-contextualized agents outperform generic chatbots
- Big tech moves validating this space (Steinberger to OpenAI, Meta's Manus, Claude Code/CoWork)
- The natural progression from reactive to proactive AI systems
- Apple's notable absence despite structural advantages

## Changes

- Add new blog post: "A Week with OpenClaw as My Personal Assistant"
- Featured post with publication date: February 16, 2026
- Includes screenshot with caption showing email processing workflow
- Tagged: ai-engineering, ai-agents, productivity, automation