### PR TITLE
Limit featured posts to 4 most recent

### DIFF
--- a/src/content/blog/course-building-ai-agents-langgraph.md
+++ b/src/content/blog/course-building-ai-agents-langgraph.md
@@ -3,7 +3,7 @@ title: "Building AI Agents with LangGraph: My First O'Reilly Course!"
 author: "Sajal Sharma"
 pubDatetime: 2025-02-17T00:00:00Z
 slug: building-ai-agents-langgraph-oreilly
-featured: true
+featured: false
 draft: false
 tags:
   - ai-agents

--- a/src/content/blog/introduction-agentic-rag.md
+++ b/src/content/blog/introduction-agentic-rag.md
@@ -3,7 +3,7 @@ title: "Agentic RAG Series - Part 1: An Introduction to Agentic RAG"
 author: "Sajal Sharma"
 pubDatetime: 2025-03-04T00:00:00Z
 slug: introduction-to-agentic-rag
-featured: true
+featured: false
 draft: false
 tags:
   - llms

--- a/src/content/blog/understanding-mcp.md
+++ b/src/content/blog/understanding-mcp.md
@@ -3,7 +3,7 @@ title: "Understanding MCP: How the Model Context Protocol Solves AI's Integratio
 author: "Sajal Sharma"
 pubDatetime: 2025-06-21T00:00:00Z
 slug: understanding-mcp
-featured: true
+featured: false
 draft: false
 tags:
   - ai-engineering


### PR DESCRIPTION
## Summary

Reduces the number of featured posts on the homepage from 7 to 4, keeping only the most recent content highlighted.

## Changes

**Unfeatured (older posts):**
- Understanding MCP (June 2025)
- Introduction to Agentic RAG (March 2025)  
- Building AI Agents with LangGraph course (February 2025)

**Still Featured (4 most recent):**
- A Week with OpenClaw as My Personal Assistant (February 2026)
- 2025 Career in Review (January 2026)
- Working Effectively with AI Coding Tools (July 2025)
- Adventures with Claude Code (July 2025)

This keeps the homepage focused on latest content while ensuring older posts remain accessible through search and tags.