### PR TITLE
Update upcoming live course dates on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,8 +53,8 @@ const socialCount = SOCIALS.filter(social => social.active).length;
         <p><strong>Take my courses on O'Reilly:</strong></p>
         <ul>
           <li><a href="https://learning.oreilly.com/course/building-ai-agents/0642572077884/" target="_blank" rel="noopener noreferrer">Building AI Agents with LangGraph</a> (on-demand course)</li>
-          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, March 11, 8pm-Midnight Singapore Standard Time)</li>
-          <li><a href="https://learning.oreilly.com/live-events/building-integrated-ai-agents-with-openclaw/0642572350437/0642572350420/" target="_blank" rel="noopener noreferrer">Building Integrated AI Agents with OpenClaw</a> (live course, April 29 at 8pm SGT)</li>
+          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, July 10, 9:30am-1:30pm India Standard Time)</li>
+          <li><a href="https://learning.oreilly.com/live-events/building-integrated-ai-agents-with-openclaw/0642572350437/0642572350420/" target="_blank" rel="noopener noreferrer">Building Integrated AI Agents with OpenClaw</a> (live course, August 25 at 8:30pm India Standard Time)</li>
         </ul>
       </div>
       

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
         <p><strong>Take my courses on O'Reilly:</strong></p>
         <ul>
           <li><a href="https://learning.oreilly.com/course/building-ai-agents/0642572077884/" target="_blank" rel="noopener noreferrer">Building AI Agents with LangGraph</a> (on-demand course)</li>
-          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, July 9, 9:00pm-1:00am Pacific Time)</li>
+          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, July 9, 9:00pm-1:00am or August 27, 9:00am-1:00pm Pacific Time)</li>
           <li><a href="https://learning.oreilly.com/live-events/building-integrated-ai-agents-with-openclaw/0642572350437/0642572350420/" target="_blank" rel="noopener noreferrer">Building Integrated AI Agents with OpenClaw</a> (live course, August 25 at 8:00am Pacific Time)</li>
         </ul>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,8 +53,8 @@ const socialCount = SOCIALS.filter(social => social.active).length;
         <p><strong>Take my courses on O'Reilly:</strong></p>
         <ul>
           <li><a href="https://learning.oreilly.com/course/building-ai-agents/0642572077884/" target="_blank" rel="noopener noreferrer">Building AI Agents with LangGraph</a> (on-demand course)</li>
-          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, July 10, 9:30am-1:30pm India Standard Time)</li>
-          <li><a href="https://learning.oreilly.com/live-events/building-integrated-ai-agents-with-openclaw/0642572350437/0642572350420/" target="_blank" rel="noopener noreferrer">Building Integrated AI Agents with OpenClaw</a> (live course, August 25 at 8:30pm India Standard Time)</li>
+          <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, July 9, 9:00pm-1:00am Pacific Time)</li>
+          <li><a href="https://learning.oreilly.com/live-events/building-integrated-ai-agents-with-openclaw/0642572350437/0642572350420/" target="_blank" rel="noopener noreferrer">Building Integrated AI Agents with OpenClaw</a> (live course, August 25 at 8:00am Pacific Time)</li>
         </ul>
       </div>
       


### PR DESCRIPTION
Updates the next scheduled dates for the live O'Reilly courses listed on the homepage.

- **Agentic RAG with LangGraph**: March 11 → July 10, 9:30am-1:30pm India Standard Time
- **Building Integrated AI Agents with OpenClaw**: April 29 → August 25 at 8:30pm India Standard Time