### PR TITLE
Improve light-mode code block color palette

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -35,7 +35,13 @@ export default defineConfig({
     ],
     rehypePlugins: ["rehype-katex"],
     shikiConfig: {
-      theme: "one-dark-pro",
+      // Dual theme: light syntax palette in light mode, one-dark-pro in dark mode.
+      // shikiji applies the light theme's colors inline and exposes the dark
+      // theme via --shiki-dark* CSS variables, which base.css swaps in for dark mode.
+      experimentalThemes: {
+        light: "github-light",
+        dark: "one-dark-pro",
+      },
       wrap: true,
     },
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,6 +55,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
           <li><a href="https://learning.oreilly.com/course/building-ai-agents/0642572077884/" target="_blank" rel="noopener noreferrer">Building AI Agents with LangGraph</a> (on-demand course)</li>
           <li><a href="https://www.oreilly.com/live-events/agentic-rag-with-langgraph/0642572176174/" target="_blank" rel="noopener noreferrer">Agentic RAG with LangGraph</a> (live course, July 9, 9:00pm-1:00am or August 27, 9:00am-1:00pm Pacific Time)</li>
           <li><a href="https://learning.oreilly.com/live-events/building-integrated-ai-agents-with-openclaw/0642572350437/0642572350420/" target="_blank" rel="noopener noreferrer">Building Integrated AI Agents with OpenClaw</a> (live course, August 25 at 8:00am Pacific Time)</li>
+          <li><a href="https://learning.oreilly.com/live-events/getting-started-with-claude-agent-sdk/0642572273255/0642572273248/" target="_blank" rel="noopener noreferrer">Getting Started with Claude Agent SDK</a> (live course, August 26, 9:00am-1:00pm Pacific Time)</li>
         </ul>
       </div>
       

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -130,6 +130,7 @@
   pre > code {
     white-space: pre;
   }
+
 }
 
 @layer components {
@@ -139,4 +140,27 @@
   .focus-outline {
     @apply outline-2 outline-offset-1 outline-skin-fill focus-visible:no-underline focus-visible:outline-dashed;
   }
+}
+
+/* ===== Shiki dual-theme code blocks =====
+   Kept OUTSIDE @layer on purpose: Tailwind tree-shakes custom selectors inside
+   @layer whose classes never appear in source files, and .astro-code only
+   exists in shiki-generated HTML. */
+
+/* Light mode: github-light tokens on GitHub's cool light-gray code surface,
+   which suits the site's cool-toned light palette better than stark white
+   (shiki inlines background-color:#fff, hence !important). */
+html[data-theme="light"] pre.astro-code {
+  background-color: #f6f8fa !important;
+  border: 1px solid rgba(var(--color-card-muted), 0.55);
+}
+
+/* Dark mode: restore one-dark-pro via the --shiki-dark* vars shikiji emits. */
+html[data-theme="dark"] .astro-code,
+html[data-theme="dark"] .astro-code span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
 }


### PR DESCRIPTION
## Summary

Code blocks previously rendered with the dark `one-dark-pro` theme in **both** light and dark mode, which looked out of place against the light page background.

This switches Shiki to **dual themes**:
- **Light mode:** `github-light` syntax tokens on a cool `#f6f8fa` surface with a soft border — harmonizes with the site's cool-toned light palette.
- **Dark mode:** `one-dark-pro`, unchanged from before.

shikiji applies the light theme inline and exposes the dark theme via `--shiki-dark*` CSS variables, which `base.css` swaps in under `html[data-theme="dark"]`. The rules live outside `@layer` so Tailwind doesn't tree-shake the shiki-only `.astro-code` selector.

## Changes
- `astro.config.ts` — `experimentalThemes` (light/dark) instead of a single theme
- `src/styles/base.css` — light-mode surface/border + dark-mode variable swap
- `src/pages/index.astro` — list the Claude Agent SDK live course on the homepage

## Verification
Checked both themes on a post with code blocks via local dev server: light mode shows the new grey surface with github-light tokens; dark mode is identical to before.