### PR TITLE
fix(newsletter): paginate Kit broadcasts via cursor, not page param

### DIFF
--- a/.github/scripts/send-newsletter.mjs
+++ b/.github/scripts/send-newsletter.mjs
@@ -87,15 +87,24 @@ async function kitFetch(endpoint, options = {}, retries = 4) {
 
 async function listAllBroadcastSubjects() {
   const subjects = new Set();
-  let page = 1;
-  while (true) {
-    const data = await kitFetch(`/broadcasts?per_page=50&page=${page}`);
-    const broadcasts = data.broadcasts || [];
-    if (broadcasts.length === 0) break;
-    for (const b of broadcasts) {
+  // Kit v4 uses cursor-based pagination; the legacy `page` parameter is no
+  // longer supported and is silently ignored, so every request returns the
+  // same first page. Paging on `page` never reaches an empty result, so the
+  // loop spun forever and hammered the API until it hit the 120 req/min rate
+  // limit. Follow `pagination.end_cursor` instead, with a hard iteration cap
+  // as a guard against an unterminated cursor.
+  let after = null;
+  for (let i = 0; i < 100; i++) {
+    const query = after
+      ? `/broadcasts?per_page=500&after=${encodeURIComponent(after)}`
+      : "/broadcasts?per_page=500";
+    const data = await kitFetch(query);
+    for (const b of data.broadcasts || []) {
       subjects.add(b.subject);
     }
-    page++;
+    const pagination = data.pagination || {};
+    if (!pagination.has_next_page || !pagination.end_cursor) break;
+    after = pagination.end_cursor;
     // Gentle throttle to stay under Kit's rate limit while paginating.
     await sleep(300);
   }


### PR DESCRIPTION
## Problem

The **Draft Newsletter** workflow was failing with repeated `Kit API 429 Too Many Requests`.

Root cause: `listAllBroadcastSubjects()` paged through existing broadcasts using the `page` query parameter, but Kit v4 dropped page/offset pagination in favor of cursors and **silently ignores `page`**. Every request returned the same first page, so the `broadcasts.length === 0` loop-exit never fired — the loop ran indefinitely (~3 req/s) until it blew past Kit's limit of 120 requests / 60s and exhausted the retry budget.

It passed originally only because the Kit account had no broadcasts yet, so the first page came back empty. Once prior newsletters existed as broadcasts, the latent bug surfaced.

## Fix

Switch to Kit v4 cursor pagination: follow `pagination.end_cursor` / `has_next_page` with `per_page=500` (the v4 default; max 1000), plus a hard iteration cap as a guard against an unterminated cursor. The lookup now completes in a single request under normal conditions, which also removes the rate-limit storm.

## Testing

- `node --check` passes.
- The live Kit API can't be exercised from CI here (the key is a repo secret); recommend a manual `workflow_dispatch` run after merge to confirm the draft is created for *Sandboxing an AI Agent*.
