### PR TITLE
Add related posts section and fix OpenClaw self-link

### DIFF
--- a/src/content/blog/sandboxing-an-ai-agent.md
+++ b/src/content/blog/sandboxing-an-ai-agent.md
@@ -178,7 +178,7 @@ The difference that matters is the billing model. [Daytona](https://www.daytona.
 
 Sandboxes are on their way to becoming a default layer of the agent stack, the way containers became the default unit of deployment. The interesting question is what happens after that.
 
-The long-horizon agents from the intro will want more than a throwaway box. Things get interesting when the sandbox stops being disposable: a persistent computer per agent means state, memory, and identity that survive across runs, which is the direction my [OpenClaw](https://milvus.io/blog/openclaw-formerly-clawdbot-moltbot-explained-a-complete-guide-to-the-autonomous-ai-agent.md) experiments keep pushing toward, giving an assistant its own machine to live on, one that persists across runs. That is a different security posture and a different design problem, and I do not think the answers are settled.
+The long-horizon agents from the intro will want more than a throwaway box. Things get interesting when the sandbox stops being disposable: a persistent computer per agent means state, memory, and identity that survive across runs, which is the direction my [OpenClaw experiments](https://sajalsharma.com/posts/openclaw-experiments) keep pushing toward, giving an assistant its own machine to live on, one that persists across runs. That is a different security posture and a different design problem, and I do not think the answers are settled.
 
 For now, the question I would leave you with is the smaller, more immediate one. The agents you are already running today, the ones with auto-approve flipped on: what computer are they running on?
 

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -1,13 +1,16 @@
 ---
+import { getCollection } from "astro:content";
 import Layout from "@layouts/Layout.astro";
 import Header from "@components/Header.astro";
 import Footer from "@components/Footer.astro";
 import Tag from "@components/Tag.astro";
 import Datetime from "@components/Datetime";
+import Card from "@components/Card";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import ShareLinks from "@components/ShareLinks.astro";
 import Newsletter from "@components/Newsletter.astro";
+import getSortedPosts from "@utils/getSortedPosts";
 
 export interface Props {
   post: CollectionEntry<"blog">;
@@ -27,6 +30,17 @@ const {
 } = post.data;
 
 const { Content } = await post.render();
+
+const allPosts = await getCollection("blog");
+const relatedPosts = getSortedPosts(allPosts)
+  .filter(p => p.slug !== post.slug)
+  .map(p => ({
+    entry: p,
+    overlap: p.data.tags.filter(tag => tags.includes(tag)).length,
+  }))
+  .sort((a, b) => b.overlap - a.overlap)
+  .slice(0, 3)
+  .map(({ entry }) => entry);
 
 const ogImageUrl = typeof ogImage === "string" ? ogImage : ogImage?.src;
 const ogUrl = new URL(
@@ -84,6 +98,19 @@ const layoutProps = {
       {tags.map(tag => <Tag tag={slugifyStr(tag)} />)}
     </ul>
 
+    {
+      relatedPosts.length > 0 && (
+        <section id="related-posts">
+          <h2>Read Next</h2>
+          <ul>
+            {relatedPosts.map(({ slug, data }) => (
+              <Card href={`/posts/${slug}`} frontmatter={data} secHeading={false} />
+            ))}
+          </ul>
+        </section>
+      )
+    }
+
     <Newsletter />
 
     <div
@@ -115,6 +142,12 @@ const layoutProps = {
   }
   .post-title {
     @apply text-2xl font-semibold text-skin-accent;
+  }
+  #related-posts {
+    @apply mb-2 mt-12;
+  }
+  #related-posts h2 {
+    @apply text-xl font-semibold tracking-wide;
   }
 </style>
 


### PR DESCRIPTION
## Summary

- Every post page now ends with a **Read Next** section: up to three related posts ranked by tag overlap, recency as tiebreaker. Drafts and scheduled posts are excluded via the existing post filter. Rendered between the tag list and the newsletter box.
- The sandboxing post's "my OpenClaw experiments" mention now links to the openclaw-experiments post instead of a third-party explainer.

## Why

From the July 2026 analytics audit: posts had no onward path (no related posts, near-zero internal links), so spike traffic bounced with nothing to click. Examples of the new routing:

- effective-ai-coding -> adventures-claude-code, openclaw-experiments, sandboxing-an-ai-agent
- sandboxing-an-ai-agent -> agentic-workflows-to-agent-harnesses, understanding-mcp, introduction-to-agentic-rag

## Verification

- npx astro check: 0 errors
- npx astro build: 97 pages built; inspected dist HTML for sandboxing-an-ai-agent and effective-ai-coding to confirm the section renders with correct links

No conflicts expected with the fix-analytics-audit branch (different files).