### PR TITLE
Fix spacing between social link icons

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,12 +30,6 @@ const { noMarginTop = false } = Astro.props;
   .footer-wrapper {
     @apply flex flex-col items-center justify-between py-6 sm:flex-row-reverse sm:py-4;
   }
-  .link-button {
-    @apply my-1 p-2 hover:rotate-6;
-  }
-  .link-button svg {
-    @apply scale-125;
-  }
   .copyright-wrapper {
     @apply my-2 flex flex-col items-center whitespace-nowrap sm:flex-row;
   }

--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -40,12 +40,12 @@ const shareLinks = [
 
 <div class={`social-icons`}>
   <span class="italic">Share this post on:</span>
-  <div class="text-center">
+  <div class="flex flex-wrap items-center justify-center gap-1">
     {
       shareLinks.map(social => (
         <LinkButton
           href={`${social.href + URL}`}
-          className="link-button"
+          className="scale-90 p-2 hover:rotate-6 sm:p-1"
           title={social.linkTitle}
         >
           <Fragment set:html={socialIcons[social.name]} />
@@ -57,10 +57,9 @@ const shareLinks = [
 </div>
 
 <style>
+  /* Scoped styles cannot reach the anchors rendered inside LinkButton, so
+     per-link utilities are passed via className above. */
   .social-icons {
     @apply flex flex-col flex-wrap items-center justify-center gap-1 sm:items-start;
-  }
-  .link-button {
-    @apply scale-90 p-2 hover:rotate-6 sm:p-1;
   }
 </style>

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -10,12 +10,12 @@ export interface Props {
 const { centered = false } = Astro.props;
 ---
 
-<div class={`social-icons ${centered ? "flex" : ""}`}>
+<div class={`social-icons ${centered ? "justify-center" : ""}`}>
   {
     SOCIALS.filter(social => social.active).map(social => (
       <LinkButton
         href={social.href}
-        className="link-button"
+        className="p-2 hover:rotate-6 sm:p-1"
         title={social.linkTitle}
       >
         <Fragment set:html={socialIcons[social.name]} />
@@ -26,10 +26,9 @@ const { centered = false } = Astro.props;
 </div>
 
 <style>
+  /* Scoped styles cannot reach the anchors rendered inside LinkButton, so
+     per-link utilities are passed via className above. */
   .social-icons {
-    @apply flex-wrap justify-center gap-1;
-  }
-  .link-button {
-    @apply p-2 hover:rotate-6 sm:p-1;
+    @apply flex flex-wrap gap-1;
   }
 </style>


### PR DESCRIPTION
## Summary

The social icons on the homepage and footer, and the share icons on post pages, rendered flush against each other with no spacing.

## Root cause

Astro scoped styles cannot reach elements rendered inside a child component. All three components passed `className="link-button"` to `LinkButton` and declared `.link-button { @apply p-2 ... }` in their scoped `<style>` blocks — but the rendered anchors never receive the parent's scope attribute, so those padding rules were dead code. On the homepage the `.social-icons` container also only became `display: flex` when the `centered` prop was set, so its `gap-1` was dead there too. Net result: zero padding, zero gap.

## Changes

- **Socials.astro**: pass `p-2 hover:rotate-6 sm:p-1` directly through `className` (global Tailwind utilities, unaffected by scoping); make the container always `flex flex-wrap gap-1`, with `centered` now toggling `justify-center` instead of `flex`
- **ShareLinks.astro**: same `className` treatment (including the intended `scale-90`); the share buttons wrapper is now a flex row with `gap-1`
- **Footer.astro**: remove its dead `.link-button` scoped rules, which also never applied

## Testing

- Verified in the browser (dev server): containers compute to `display: flex` with 4px gap; anchors get 4px padding on desktop (`sm:p-1`) and 8px on mobile (`p-2`), i.e. 32px/40px hit areas — previously bare 24px icons touching each other
- Checked homepage, footer (centered), and post share links, at desktop and mobile widths; no console errors
- `npm run build` (astro check + build + jampack) passes; changed files pass ESLint and Prettier