### PR TITLE
fix(ui): rename related posts heading to "Read Next" and self-link OpenClaw

### DIFF
--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -16,7 +16,7 @@ const { posts } = Astro.props;
         id="related-posts-heading"
         class="border-l-4 border-skin-accent border-opacity-80 pl-4 text-2xl font-semibold"
       >
-        Related Posts
+        Read Next
       </h2>
       <ul>
         {posts.map(post => (

--- a/src/content/blog/sandboxing-an-ai-agent.md
+++ b/src/content/blog/sandboxing-an-ai-agent.md
@@ -178,7 +178,7 @@ The difference that matters is the billing model. [Daytona](https://www.daytona.
 
 Sandboxes are on their way to becoming a default layer of the agent stack, the way containers became the default unit of deployment. The interesting question is what happens after that.
 
-The long-horizon agents from the intro will want more than a throwaway box. Things get interesting when the sandbox stops being disposable: a persistent computer per agent means state, memory, and identity that survive across runs, which is the direction my [OpenClaw](https://milvus.io/blog/openclaw-formerly-clawdbot-moltbot-explained-a-complete-guide-to-the-autonomous-ai-agent.md) experiments keep pushing toward, giving an assistant its own machine to live on, one that persists across runs. That is a different security posture and a different design problem, and I do not think the answers are settled.
+The long-horizon agents from the intro will want more than a throwaway box. Things get interesting when the sandbox stops being disposable: a persistent computer per agent means state, memory, and identity that survive across runs, which is the direction my [OpenClaw](https://sajalsharma.com/posts/openclaw-experiments) experiments keep pushing toward, giving an assistant its own machine to live on, one that persists across runs. That is a different security posture and a different design problem, and I do not think the answers are settled.
 
 For now, the question I would leave you with is the smaller, more immediate one. The agents you are already running today, the ones with auto-approve flipped on: what computer are they running on?
 


### PR DESCRIPTION
Two small content/UI fixes:

- **Rename related-posts heading to "Read Next".** The post-page section now reads "Read Next" instead of "Related Posts" — more natural, and reads as a call to the reader rather than a category label. Change is in `src/components/RelatedPosts.astro`; the section id and aria attributes are unchanged.
- **Self-link the OpenClaw reference in the sandboxing post.** The "OpenClaw" mention in `sandboxing-an-ai-agent.md` linked to an external write-up; it now points to the on-site OpenClaw post (`/posts/openclaw-experiments`), matching how other internal posts are cross-referenced.

## Verification
- Ran the dev server and confirmed on the sandboxing post page that the heading renders as "Read Next" and the OpenClaw body link resolves to `https://sajalsharma.com/posts/openclaw-experiments`.
- `related:check` reports the artifact is up to date (the URL edit does not affect embeddings).