### PR TITLE
feat(seo): add llms.txt endpoints and full-content RSS feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,14 @@ Each post page shows up to 3 related posts (5 stored), precomputed at authoring 
 The `/og.png.ts` endpoint dynamically generates Open Graph images. Custom templates live in `src/utils/og-templates/`.
 
 ### RSS Feed
-Auto-generated at `/rss.xml` from all published posts.
+Auto-generated at `/rss.xml` from all published posts. Full-content feed: each item's `content:encoded` carries the whole post, rendered from raw markdown with `markdown-it` + `sanitize-html`. Autodiscoverable via `<link rel="alternate">` in `Layout.astro`.
+
+### llms.txt (AI assistant discovery)
+Two static endpoints make the content easy for AI assistants to discover and cite:
+- `/llms.txt` (`src/pages/llms.txt.ts`) — an [llmstxt.org](https://llmstxt.org)-format index: title + description + absolute URL for every published post, plus key pages
+- `/llms-full.txt` (`src/pages/llms-full.txt.ts`) — the full text of every post as clean markdown, one fetch for the whole corpus
+
+Both reuse `getSortedPosts`/`postFilter` (no draft/scheduled leakage) and share URL helpers: `getPostBody` (strips the injected `## Table of contents` heading) and `absolutizeUrls` (rewrites root-relative `/images` and `/posts` paths to absolute, also used by the RSS feed). Pure string-building, no API calls — generated statically at build.
 
 ### SEO
 - Sitemap auto-generated via `@astrojs/sitemap`

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,10 @@
         "@divriots/jampack": "^0.34.1",
         "@tailwindcss/typography": "^0.5.10",
         "@types/github-slugger": "^1.3.0",
+        "@types/markdown-it": "^14.1.2",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.3.0",
+        "@types/sanitize-html": "^2.16.1",
         "@typescript-eslint/parser": "^6.18.1",
         "astro-eslint-parser": "^0.16.0",
         "autoprefixer": "^10.4.20",
@@ -41,12 +43,14 @@
         "gray-matter": "^4.0.3",
         "husky": "^8.0.3",
         "lint-staged": "^15.2.0",
+        "markdown-it": "^14.3.0",
         "openai": "^6.46.0",
         "prettier": "^3.1.1",
         "prettier-plugin-astro": "^0.12.3",
         "prettier-plugin-tailwindcss": "^0.5.11",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "sanitize-html": "^2.17.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4834,6 +4838,24 @@
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
       "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4842,6 +4864,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
@@ -4888,6 +4917,64 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/@types/sax": {
@@ -7832,6 +7919,13 @@
         "@commitlint/load": ">6.1.1"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -10243,6 +10337,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -10454,6 +10558,16 @@
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
       }
     },
     "node_modules/levn": {
@@ -10739,6 +10853,26 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/lint-staged": {
       "version": "15.5.2",
@@ -11145,6 +11279,34 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "optional": true
     },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -11474,6 +11636,13 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge": {
       "version": "2.1.1",
@@ -12729,6 +12898,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -13212,6 +13388,16 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -14040,6 +14226,145 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.6",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
+      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^12.0.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/sass-formatter": {
       "version": "0.7.8",
@@ -15199,6 +15524,13 @@
       "dependencies": {
         "semver": "^7.3.8"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "@divriots/jampack": "^0.34.1",
     "@tailwindcss/typography": "^0.5.10",
     "@types/github-slugger": "^1.3.0",
+    "@types/markdown-it": "^14.1.2",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.3.0",
+    "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/parser": "^6.18.1",
     "astro-eslint-parser": "^0.16.0",
     "autoprefixer": "^10.4.20",
@@ -54,12 +56,14 @@
     "gray-matter": "^4.0.3",
     "husky": "^8.0.3",
     "lint-staged": "^15.2.0",
+    "markdown-it": "^14.3.0",
     "openai": "^6.46.0",
     "prettier": "^3.1.1",
     "prettier-plugin-astro": "^0.12.3",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "sanitize-html": "^2.17.6"
   },
   "config": {
     "commitizen": {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -41,6 +41,12 @@ const socialImageURL = new URL(
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title={`${SITE.title} RSS Feed`}
+      href="/rss.xml"
+    />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
 

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,57 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import getSortedPosts from "@utils/getSortedPosts";
+import getPostBody from "@utils/getPostBody";
+import { absolutizeMarkdown } from "@utils/absolutizeUrls";
+import { SITE } from "@config";
+
+/**
+ * /llms-full.txt - the full text of every published post as clean markdown.
+ *
+ * One fetch gives an AI assistant the entire corpus (raw markdown, which LLMs
+ * consume better than rendered HTML), each section prefixed with the post's
+ * title, canonical URL, and dates so quotes can be attributed correctly.
+ */
+export const GET: APIRoute = async () => {
+  const posts = await getCollection("blog");
+  const sortedPosts = getSortedPosts(posts);
+
+  const documents = sortedPosts.map(post => {
+    const { data, id } = post;
+    const url = new URL(`posts/${id}/`, SITE.website).href;
+    const published = data.pubDatetime.toISOString().slice(0, 10);
+    const updated = data.modDatetime
+      ? data.modDatetime.toISOString().slice(0, 10)
+      : null;
+
+    const meta = [
+      `# ${data.title}`,
+      "",
+      `Source: ${url}`,
+      `Author: ${data.author}`,
+      `Published: ${published}${updated ? ` | Updated: ${updated}` : ""}`,
+      data.tags.length ? `Tags: ${data.tags.join(", ")}` : null,
+      "",
+      data.description,
+    ]
+      .filter(line => line !== null)
+      .join("\n");
+
+    return `${meta}\n\n${absolutizeMarkdown(getPostBody(post))}`;
+  });
+
+  const body = [
+    `# ${SITE.author} — Full Blog Content`,
+    "",
+    `> ${SITE.desc}`,
+    "",
+    "Every published post in full, as markdown. Free to read and cite with attribution.",
+    "",
+    documents.join("\n\n---\n\n"),
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,48 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import getSortedPosts from "@utils/getSortedPosts";
+import { SITE } from "@config";
+
+/**
+ * /llms.txt - an llmstxt.org-format index of the site for AI assistants.
+ *
+ * A curated map (title + description + absolute URL) of every published post
+ * plus key pages, so an assistant can discover and cite the content. The full
+ * prose lives in /llms-full.txt; this file is the table of contents.
+ */
+export const GET: APIRoute = async () => {
+  const posts = await getCollection("blog");
+  const sortedPosts = getSortedPosts(posts);
+
+  const postLines = sortedPosts.map(({ data, id }) => {
+    const url = new URL(`posts/${id}/`, SITE.website).href;
+    return `- [${data.title}](${url}): ${data.description}`;
+  });
+
+  const pageLines = [
+    `- [About](${new URL("about", SITE.website).href}): About ${SITE.author} — background, experience, and work.`,
+    `- [Blog](${new URL("posts", SITE.website).href}): All blog posts.`,
+    `- [Full content](${new URL("llms-full.txt", SITE.website).href}): Every post's full text as markdown.`,
+  ];
+
+  const body = [
+    `# ${SITE.author}`,
+    "",
+    `> ${SITE.desc}`,
+    "",
+    "This site publishes long-form writing on agentic AI systems, LLMs, RAG, and machine learning engineering. Content is free to read and cite with attribution.",
+    "",
+    "## Blog Posts",
+    "",
+    ...postLines,
+    "",
+    "## Pages",
+    "",
+    ...pageLines,
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,7 +1,13 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
+import MarkdownIt from "markdown-it";
+import sanitizeHtml from "sanitize-html";
 import getSortedPosts from "@utils/getSortedPosts";
+import getPostBody from "@utils/getPostBody";
+import { absolutizeHtml } from "@utils/absolutizeUrls";
 import { SITE } from "@config";
+
+const parser = new MarkdownIt({ html: true, linkify: true });
 
 export async function GET() {
   const posts = await getCollection("blog");
@@ -10,11 +16,24 @@ export async function GET() {
     title: SITE.title,
     description: SITE.desc,
     site: SITE.website,
-    items: sortedPosts.map(({ data, id }) => ({
-      link: `posts/${id}`,
-      title: data.title,
-      description: data.description,
-      pubDate: new Date(data.modDatetime ?? data.pubDatetime),
-    })),
+    items: sortedPosts.map(post => {
+      const { data, id } = post;
+      const content = absolutizeHtml(
+        sanitizeHtml(parser.render(getPostBody(post)), {
+          allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+          allowedAttributes: {
+            ...sanitizeHtml.defaults.allowedAttributes,
+            img: ["src", "alt", "title"],
+          },
+        })
+      );
+      return {
+        link: `posts/${id}`,
+        title: data.title,
+        description: data.description,
+        pubDate: new Date(data.modDatetime ?? data.pubDatetime),
+        content,
+      };
+    }),
   });
 }

--- a/src/utils/absolutizeUrls.ts
+++ b/src/utils/absolutizeUrls.ts
@@ -1,0 +1,14 @@
+import { SITE } from "@config";
+
+// Posts use root-relative paths for images (/images/blog/...) and some internal
+// links (/posts/...). Those only resolve on this domain, so exports meant to be
+// read elsewhere (the feed, llms-full.txt) must rewrite them to absolute URLs.
+const base = SITE.website.replace(/\/$/, "");
+
+/** Rewrite root-relative src/href attributes in rendered HTML to absolute URLs. */
+export const absolutizeHtml = (html: string): string =>
+  html.replace(/(src|href)="\/(?!\/)/g, `$1="${base}/`);
+
+/** Rewrite root-relative markdown link/image targets — ](/path) — to absolute URLs. */
+export const absolutizeMarkdown = (markdown: string): string =>
+  markdown.replace(/\]\(\/(?!\/)/g, `](${base}/`);

--- a/src/utils/getPostBody.ts
+++ b/src/utils/getPostBody.ts
@@ -1,0 +1,17 @@
+import type { CollectionEntry } from "astro:content";
+
+/**
+ * Returns a post's raw markdown body cleaned for plain-text/LLM export.
+ *
+ * Strips the injected "## Table of contents" heading (remark-toc fills the list
+ * in at render time, so the raw body carries only an empty heading that would
+ * otherwise leak into llms-full.txt and the RSS content) and collapses the
+ * blank lines it leaves behind.
+ */
+const getPostBody = (post: CollectionEntry<"blog">): string =>
+  (post.body ?? "")
+    .replace(/^##\s+Table of contents\s*$/im, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+export default getPostBody;


### PR DESCRIPTION
## Why

AI-assistant referrals are a real and growing traffic source (~280 sessions this year). This makes the site's writing easy for AI assistants and feed readers to discover and cite in full, rather than seeing only post descriptions.

## What

- **`/llms.txt`** — an [llmstxt.org](https://llmstxt.org)-format index: every published post (title, description, absolute URL) plus key pages.
- **`/llms-full.txt`** — the full text of every post as clean markdown in a single fetch (the actual citation payload; LLMs consume raw markdown better than rendered HTML).
- **Full-content RSS** — `rss.xml` now emits `content:encoded` per item with the whole post, rendered from markdown via `markdown-it` + `sanitize-html`.
- **RSS autodiscovery** — added the `<link rel="alternate" type="application/rss+xml">` tag to the layout head (was missing).

## Implementation notes

- Shared helpers keep exports self-contained: `getPostBody` strips the injected `## Table of contents` heading, and `absolutizeUrls` rewrites root-relative `/images` and `/posts` paths to absolute URLs (used by both the full feed and llms-full.txt).
- All exports reuse `getSortedPosts`/`postFilter`, so drafts and scheduled posts never leak.
- Everything is generated statically at build — no runtime, no API keys, no CI impact. `markdown-it`/`sanitize-html` are build-time devDeps only.
- robots.txt is unchanged (the existing blanket `Allow: /` already permits AI crawlers); no per-post `.md` endpoints in this pass.

## Verification

- `astro check`: 0 errors, 0 warnings.
- `astro build`: clean; `llms.txt` (5.9 KB), `llms-full.txt` (303 KB), `rss.xml` (359 KB) all emit to `dist/`.
- `/llms.txt`: 18 posts (matches published count), absolute URLs, correct Pages section.
- `/llms-full.txt`: 18 documents, 0 TOC leaks, 0 remaining root-relative image paths.
- `/rss.xml`: well-formed XML (`xmllint`), full prose + absolute images inside `content:encoded`, no root-relative leaks.