### PR TITLE
Track link clicks with GA4 link_click events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Configured in `astro.config.ts` using the `unified()` processor from `@astrojs/m
 ### Component Structure
 
 **Layout Components:**
-- `Layout.astro`: Base layout with SEO, analytics (Google Analytics via Partytown)
+- `Layout.astro`: Base layout with SEO, analytics (Google Analytics gtag on the main thread, plus the delegated `link_click` listener)
 - `Main.astro`: Main content wrapper
 - `PostDetails.astro`: Blog post layout
 - `Posts.astro`: Blog listing layout
@@ -133,11 +133,24 @@ Each post page shows up to 3 related posts (5 stored), precomputed at authoring 
 - Committed artifact: `src/generated/related-posts.json` (keys/values are entry ids, which mirror `generateId` in `src/content.config.ts`). Embedding vectors live in the gitignored `.cache/related-posts/`, cached per summary and per body chunk: title/description edits re-embed one summary, body edits re-embed only the changed chunks, and tag or config changes re-rank locally with no API call (fenced code never affects embeddings)
 - `npm run dev` and `npm run build` run `related:ensure`, which never fails a build: without `OPENAI_API_KEY` it warns and keeps the committed artifact. GitHub Actions therefore needs no OpenAI credentials and must not be given any — regeneration happens locally, enforced by the pre-commit `related:check`
 
+### Analytics (GA4 link-click tracking)
+GA4 loads as a plain async main-thread script in `Layout.astro`, gated on the build-time `GA_TRACKING_ID` env var and a runtime `sajalsharma.com` hostname check (Partytown was removed: its worker transport dropped most events, and main-thread cost measured at 0 Lighthouse points / +9-14ms TBT). A delegated listener in `Layout.astro` fires a `link_click` event for every anchor click (`click` + middle-click `auxclick`; same-document hash jumps skipped) with params `link_section`, `link_url`, `link_domain`, `link_text`, `outbound` — the last four reuse Enhanced Measurement's names so GA4's built-in dimensions pick them up; `link_section` is a registered event-scoped custom dimension:
+- `link_section` comes from the nearest `data-track` container attribute (`header`, `footer`, `socials`, `share-links`, `related-posts`, `pagination`, `breadcrumbs`, `search-results`, `home-hero`, `courses`, `featured-posts`, `home-all-posts`, `posts-list`, `post-body`, `post-tags`, `about`), falling back to `other`. When adding a new link-bearing section, put `data-track` on its container — never on individual anchors; `LinkButton.astro` does not forward extra props
+- Off-production hostnames log the payload via `console.debug("[link_click]", ...)` instead of sending — click through pages in the dev server to verify
+- Query from the terminal with the `ga4` CLI (see `.claude/skills/ga4-cli`), e.g. `ga4 report -m eventCount -d customEvent:link_section -f 'eventName==link_click' -r 28d`
+
 ### OG Image Generation
 The `/og.png.ts` endpoint dynamically generates Open Graph images. Custom templates live in `src/utils/og-templates/`.
 
 ### RSS Feed
-Auto-generated at `/rss.xml` from all published posts.
+Auto-generated at `/rss.xml` from all published posts. Full-content feed: each item's `content:encoded` carries the whole post, rendered from raw markdown with `markdown-it` + `sanitize-html`. Autodiscoverable via `<link rel="alternate">` in `Layout.astro`.
+
+### llms.txt (AI assistant discovery)
+Two static endpoints make the content easy for AI assistants to discover and cite:
+- `/llms.txt` (`src/pages/llms.txt.ts`) — an [llmstxt.org](https://llmstxt.org)-format index: title + description + absolute URL for every published post, plus key pages
+- `/llms-full.txt` (`src/pages/llms-full.txt.ts`) — the full text of every post as clean markdown, one fetch for the whole corpus
+
+Both reuse `getSortedPosts`/`postFilter` (no draft/scheduled leakage) and share URL helpers: `getPostBody` (strips the injected `## Table of contents` heading) and `absolutizeUrls` (rewrites root-relative `/images` and `/posts` paths to absolute, also used by the RSS feed). Pure string-building, no API calls — generated statically at build.
 
 ### SEO
 - Sitemap auto-generated via `@astrojs/sitemap`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Configured in `astro.config.ts` using the `unified()` processor from `@astrojs/m
 ### Component Structure
 
 **Layout Components:**
-- `Layout.astro`: Base layout with SEO, analytics (Google Analytics via Partytown)
+- `Layout.astro`: Base layout with SEO, analytics (Google Analytics gtag on the main thread, plus the delegated `link_click` listener)
 - `Main.astro`: Main content wrapper
 - `PostDetails.astro`: Blog post layout
 - `Posts.astro`: Blog listing layout
@@ -132,6 +132,12 @@ Each post page shows up to 3 related posts (5 stored), precomputed at authoring 
 - `scripts/related-posts.mjs` scores every pair with four signals, each producing its own per-source ranking: title+description embedding cosine (OpenAI `text-embedding-3-large`), symmetric body-chunk coverage (cleaned prose in ~375-word chunks; fenced code, HTML, and generic heading labels like "Introduction" are stripped first), symmetric BM25F lexical similarity (title/description/body fields, each direction normalized by its query's IDF mass), and IDF-weighted tag overlap. Rankings fuse via weighted RRF (0.45 title+description / 0.25 body / 0.25 BM25F / 0.05 tags, K=10); an absolute evidence gate then admits a candidate only on strong title+description cosine (>= 0.60) or body coverage and lexical similarity agreeing independently (>= 0.512 and >= 0.035). Tags never admit a candidate alone. Manual `relatedPosts` pins and series neighbors outrank automatic results and bypass the gate — posts may legitimately have fewer than 3 related posts or none. Recalibrate gate thresholds with `npm run related:report` after changing scoring; pin cross-topic pairs the signals undervalue via `relatedPosts` instead of lowering thresholds
 - Committed artifact: `src/generated/related-posts.json` (keys/values are entry ids, which mirror `generateId` in `src/content.config.ts`). Embedding vectors live in the gitignored `.cache/related-posts/`, cached per summary and per body chunk: title/description edits re-embed one summary, body edits re-embed only the changed chunks, and tag or config changes re-rank locally with no API call (fenced code never affects embeddings)
 - `npm run dev` and `npm run build` run `related:ensure`, which never fails a build: without `OPENAI_API_KEY` it warns and keeps the committed artifact. GitHub Actions therefore needs no OpenAI credentials and must not be given any — regeneration happens locally, enforced by the pre-commit `related:check`
+
+### Analytics (GA4 link-click tracking)
+GA4 loads as a plain async main-thread script in `Layout.astro`, gated on the build-time `GA_TRACKING_ID` env var and a runtime `sajalsharma.com` hostname check (Partytown was removed: its worker transport dropped most events, and main-thread cost measured at 0 Lighthouse points / +9-14ms TBT). A delegated listener in `Layout.astro` fires a `link_click` event for every anchor click (`click` + middle-click `auxclick`; same-document hash jumps skipped) with params `link_section`, `link_url`, `link_domain`, `link_text`, `outbound` — the last four reuse Enhanced Measurement's names so GA4's built-in dimensions pick them up; `link_section` is a registered event-scoped custom dimension:
+- `link_section` comes from the nearest `data-track` container attribute (`header`, `footer`, `socials`, `share-links`, `related-posts`, `pagination`, `breadcrumbs`, `search-results`, `home-hero`, `courses`, `featured-posts`, `home-all-posts`, `posts-list`, `post-body`, `post-tags`, `about`), falling back to `other`. When adding a new link-bearing section, put `data-track` on its container — never on individual anchors; `LinkButton.astro` does not forward extra props
+- Off-production hostnames log the payload via `console.debug("[link_click]", ...)` instead of sending — click through pages in the dev server to verify
+- Query from the terminal with the `ga4` CLI (see `.claude/skills/ga4-cli`), e.g. `ga4 report -m eventCount -d customEvent:link_section -f 'eventName==link_click' -r 28d`
 
 ### OG Image Generation
 The `/og.png.ts` endpoint dynamically generates Open Graph images. Custom templates live in `src/utils/og-templates/`.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -7,7 +7,6 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import sitemap from "@astrojs/sitemap";
 import { SITE } from "./src/config";
-import partytown from "@astrojs/partytown";
 
 // https://astro.build/config
 export default defineConfig({
@@ -21,15 +20,7 @@ export default defineConfig({
     "/posts/overview-multi-agent-fameworks":
       "/posts/overview-multi-agent-frameworks/",
   },
-  integrations: [
-    react(),
-    sitemap(),
-    partytown({
-      config: {
-        forward: ["dataLayer.push"],
-      },
-    }),
-  ],
+  integrations: [react(), sitemap()],
   markdown: {
     // Keep the remark/rehype pipeline (TOC, collapsible sections, LaTeX math)
     // instead of Astro 7's default Sätteri processor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/markdown-remark": "^7.2.1",
-        "@astrojs/partytown": "^2.1.7",
         "@astrojs/rss": "^4.0.19",
         "@resvg/resvg-js": "^2.6.0",
         "astro": "^7.0.7",
@@ -423,16 +422,6 @@
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "satteri": "^0.9.1"
-      }
-    },
-    "node_modules/@astrojs/partytown": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.7.tgz",
-      "integrity": "sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@qwik.dev/partytown": "^0.13.2",
-        "mrmime": "^2.0.1"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -3383,21 +3372,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/@qwik.dev/partytown": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.13.2.tgz",
-      "integrity": "sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==",
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.4.7"
-      },
-      "bin": {
-        "partytown": "bin/partytown.cjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@resvg/resvg-js": {
@@ -8254,18 +8228,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dset": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/markdown-remark": "^7.2.1",
-    "@astrojs/partytown": "^2.1.7",
     "@astrojs/rss": "^4.0.19",
     "@resvg/resvg-js": "^2.6.0",
     "astro": "^7.0.7",

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -24,7 +24,7 @@ breadcrumbList[0] === "tags" &&
   );
 ---
 
-<nav class="breadcrumb" aria-label="breadcrumb">
+<nav class="breadcrumb" aria-label="breadcrumb" data-track="breadcrumbs">
   <ul>
     <li>
       <a href="/">Home</a>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,7 @@ export interface Props {
 const { noMarginTop = false } = Astro.props;
 ---
 
-<footer class={`${noMarginTop ? "" : "mt-auto"}`}>
+<footer class={`${noMarginTop ? "" : "mt-auto"}`} data-track="footer">
   <Hr noPadding />
   <div class="footer-wrapper">
     <Socials centered />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,7 +11,7 @@ export interface Props {
 const { activeNav } = Astro.props;
 ---
 
-<header>
+<header data-track="header">
   <a id="skip-to-content" href="#main-content">Skip to content</a>
   <div class="nav-container">
     <div class="top-nav-wrap">

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -98,8 +98,8 @@
     forms.forEach(form => {
       // Handle form submissions
       form.addEventListener('submit', function() {
-        // GA4 conversion event; dataLayer.push is forwarded to the Partytown
-        // worker where gtag.js runs (see Layout.astro).
+        // GA4 conversion event; gtag.js runs on the main thread (see
+        // Layout.astro) and picks this up from the shared dataLayer.
         window.dataLayer = window.dataLayer || [];
         var gtag = function () {
           window.dataLayer.push(arguments);

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -16,7 +16,7 @@ const next = currentPage < totalPages ? "" : "disabled";
 
 {
   totalPages > 1 && (
-    <nav class="pagination-wrapper" aria-label="Pagination">
+    <nav class="pagination-wrapper" aria-label="Pagination" data-track="pagination">
       <LinkButton
         disabled={prev === "disabled"}
         href={prevUrl}

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -11,7 +11,11 @@ const { posts } = Astro.props;
 
 {
   posts.length > 0 && (
-    <section id="related-posts" aria-labelledby="related-posts-heading">
+    <section
+      id="related-posts"
+      aria-labelledby="related-posts-heading"
+      data-track="related-posts"
+    >
       <h2
         id="related-posts-heading"
         class="border-l-4 border-skin-accent border-opacity-80 pl-4 text-2xl font-semibold"

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -108,7 +108,7 @@ export default function SearchBar({ searchList }: Props) {
         </div>
       )}
 
-      <ul>
+      <ul data-track="search-results">
         {searchResults &&
           searchResults.map(({ item, refIndex }) => (
             <Card

--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -38,7 +38,7 @@ const shareLinks = [
 ] as const;
 ---
 
-<div class={`social-icons`}>
+<div class={`social-icons`} data-track="share-links">
   <span class="italic">Share this post on:</span>
   <div class="flex flex-wrap items-center justify-center gap-1">
     {

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -10,7 +10,10 @@ export interface Props {
 const { centered = false } = Astro.props;
 ---
 
-<div class={`social-icons ${centered ? "justify-center" : ""}`}>
+<div
+  class={`social-icons ${centered ? "justify-center" : ""}`}
+  data-track="socials"
+>
   {
     SOCIALS.filter(social => social.active).map(social => (
       <LinkButton

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -19,7 +19,11 @@ const { frontmatter } = Astro.props;
   <Header activeNav="about" />
   <Breadcrumbs />
   <main id="main-content">
-    <section id="about" class="prose mb-28 max-w-3xl prose-img:border-0">
+    <section
+      id="about"
+      class="prose mb-28 max-w-3xl prose-img:border-0"
+      data-track="about"
+    >
       <h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>
       <slot />
     </section>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -110,11 +110,14 @@ const socialImageURL = new URL(
       )
     }
 
-    <!-- Google tag (gtag.js) -->
+    <!-- Google tag (gtag.js). Runs on the main thread: Partytown's worker
+         proxying dropped most events (QwikDev/partytown#603), and gtag's
+         native beacon transport must live on the main thread to survive
+         same-tab navigations. -->
     {import.meta.env.GA_TRACKING_ID && (
       <>
-        <script type="text/partytown" async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.GA_TRACKING_ID}`}></script>
-        <script type="text/partytown" define:vars={{ gaId: import.meta.env.GA_TRACKING_ID }}>
+        <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.GA_TRACKING_ID}`}></script>
+        <script is:inline define:vars={{ gaId: import.meta.env.GA_TRACKING_ID }}>
           // Only configure GA on the production hostname so localhost and
           // forks serving this HTML don't pollute the property.
           if (window.location.hostname === "sajalsharma.com") {
@@ -128,6 +131,70 @@ const socialImageURL = new URL(
         </script>
       </>
     )}
+
+    <!-- Delegated link-click tracking: every anchor click becomes a GA4
+         "link_click" event attributed to the nearest [data-track] container. -->
+    <script is:inline>
+      (function () {
+        function trackLinkClick(e) {
+          // auxclick also fires for right-click; only middle-click follows the link.
+          if (e.type === "auxclick" && e.button !== 1) return;
+          var anchor =
+            e.target instanceof Element ? e.target.closest("a[href]") : null;
+          if (!anchor) return;
+          var url;
+          try {
+            url = new URL(anchor.href);
+          } catch (_) {
+            return;
+          }
+          var httpish = url.protocol === "http:" || url.protocol === "https:";
+          // Same-document hash jumps (heading permalinks, in-post TOC,
+          // skip-to-content) are not link clicks.
+          if (
+            httpish &&
+            url.hostname === window.location.hostname &&
+            url.pathname === window.location.pathname &&
+            url.search === window.location.search &&
+            url.hash
+          ) {
+            return;
+          }
+          var container = anchor.closest("[data-track]");
+          // GA4 truncates event parameter values beyond 100 characters;
+          // cutting here keeps the truncation deterministic.
+          var params = {
+            link_section: container
+              ? container.getAttribute("data-track")
+              : "other",
+            link_url: anchor.href.slice(0, 100),
+            link_domain: httpish ? url.hostname : url.protocol.replace(":", ""),
+            link_text: (
+              anchor.getAttribute("aria-label") ||
+              anchor.getAttribute("title") ||
+              anchor.textContent ||
+              ""
+            )
+              .trim()
+              .replace(/\s+/g, " ")
+              .slice(0, 100),
+            outbound: !httpish || url.hostname !== window.location.hostname,
+          };
+          if (window.location.hostname !== "sajalsharma.com") {
+            console.debug("[link_click]", params);
+            return;
+          }
+          window.dataLayer = window.dataLayer || [];
+          // gtag.js only processes arguments-object pushes, not arrays.
+          var gtag = function () {
+            window.dataLayer.push(arguments);
+          };
+          gtag("event", "link_click", params);
+        }
+        document.addEventListener("click", trackLinkClick);
+        document.addEventListener("auxclick", trackLinkClick);
+      })();
+    </script>
 
     <script is:inline src="/toggle-theme.js"></script>
   </head>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -81,13 +81,18 @@ const layoutProps = {
       size="lg"
       className="my-2"
     />
-    <article id="article" role="article" class="prose mx-auto mt-8 max-w-3xl">
+    <article
+      id="article"
+      role="article"
+      class="prose mx-auto mt-8 max-w-3xl"
+      data-track="post-body"
+    >
       <Content />
     </article>
 
     <RelatedPosts posts={relatedPosts} />
 
-    <ul class="my-8">
+    <ul class="my-8" data-track="post-tags">
       {tags.map(tag => <Tag tag={slugifyStr(tag)} />)}
     </ul>
 
@@ -129,6 +134,9 @@ const layoutProps = {
   function addHeadingLinks() {
     let headings = Array.from(document.querySelectorAll("h2, h3, h4, h5, h6"));
     for (let heading of headings) {
+      // Headings outside the article body (e.g. Read Next card titles) have
+      // no id, so a permalink would be a dead "#" link.
+      if (!heading.id) continue;
       heading.classList.add("group");
       let link = document.createElement("a");
       link.innerText = "#";

--- a/src/layouts/Posts.astro
+++ b/src/layouts/Posts.astro
@@ -20,7 +20,7 @@ const { currentPage, totalPages, paginatedPosts } = Astro.props;
 <Layout title={`Posts | ${SITE.title}`}>
   <Header activeNav="posts" />
   <Main pageTitle="Posts" pageDesc="All the articles I've posted.">
-    <ul>
+    <ul data-track="posts-list">
       {
         paginatedPosts.map(({ data, id }) => (
           <Card href={`/posts/${id}`} frontmatter={data} />

--- a/src/layouts/TagPosts.astro
+++ b/src/layouts/TagPosts.astro
@@ -27,7 +27,7 @@ const { currentPage, totalPages, paginatedPosts, tag, tagName } = Astro.props;
     pageDesc={`All the articles with the tag "${tagName}".`}
   >
     <h1 slot="title" transition:name={tag}>{`Tag:${tag}`}</h1>
-    <ul>
+    <ul data-track="posts-list">
       {
         paginatedPosts.map(({ data, id }) => (
           <Card href={`/posts/${id}`} frontmatter={data} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
 <Layout title="Sajal Sharma | AI Engineer | O'Reilly Instructor">
   <Header />
   <main id="main-content">
-    <section id="hero">
+    <section id="hero" data-track="home-hero">
       <h1>Hello! 👋</h1>
       
       <!-- Uncomment below to include RSS icon. -->
@@ -49,7 +49,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
 
       <p>Explore my journey and insights on AI & ML through my <a href="/posts">blog</a>, or read more about my <a href="/about">professional experience</a>. 🚀</p>
 
-      <div class="courses-section">
+      <div class="courses-section" data-track="courses">
         <p><strong>Take my courses on O'Reilly:</strong></p>
         <ul>
           <li><a href="https://learning.oreilly.com/course/building-ai-agents/0642572077884/" target="_blank" rel="noopener noreferrer">Building AI Agents with LangGraph</a> (on-demand course)</li>
@@ -77,7 +77,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
     {
       featuredPosts.length > 0 && (
         <>
-          <section id="featured">
+          <section id="featured" data-track="featured-posts">
             <h2>Featured Posts</h2>
             <ul>
               {featuredPosts.map(({ data, id }) => (
@@ -94,7 +94,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
     }
 
 
-    <div class="all-posts-btn-wrapper">
+    <div class="all-posts-btn-wrapper" data-track="home-all-posts">
       <LinkButton href="/posts">
         All Posts
         <svg xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -14,7 +14,7 @@ const sortedPosts = getSortedPosts(posts);
 <Layout title={`Posts | ${SITE.title}`}>
   <Header activeNav="posts" />
   <Main pageTitle="Posts" pageDesc="Here I document my experiments with AI engineering, insights from building intelligent systems and share deep dives on latest paradigms.">
-    <ul class="posts-list">
+    <ul class="posts-list" data-track="posts-list">
       {
         sortedPosts.map(({ data, id }) => (
           <li class="post-item">


### PR DESCRIPTION
## What

Site-wide link-click tracking: every anchor click fires a GA4 `link_click` event with `link_section` (from the nearest `data-track` container), `link_url`, `link_domain`, `link_text`, and `outbound` params. Covers internal links (nav, post cards, related posts, tags, pagination, search results, in-post links) and outbound ones (courses, socials, references).

## Why gtag moved off Partytown

The Partytown worker transport was dropping the large majority of engagement and scroll events on this property (a documented open issue: QwikDev/partytown#603), and gtag's beacon-on-unload delivery only works with main-thread gtag. A 5-run median Lighthouse A/B on identical production builds measured the cost of removal:

| | Partytown | Main thread |
|---|---|---|
| Score (home / post) | 93 / 93 | 93 / 93 |
| TBT | 0 ms | 9-14 ms |
| FCP / LCP / SI | — | unchanged |

## Also

- Heading permalinks are no longer injected into id-less headings (Read Next card titles were getting dead `#` anchors, which would have polluted the click data)
- `link_url`/`link_domain`/`link_text`/`outbound` reuse Enhanced Measurement param names so GA4's built-in dimensions populate without extra custom-dimension quota
- Off-production hostnames log `[link_click]` payloads to the console instead of sending

## Verified

- Click-through on dev server: all 16 sections log correct payloads; negatives (same-page hash links, right-button auxclick) stay silent; middle-click auxclick and React-rendered search results covered; mailto share links resolve to `link_domain: mailto`
- Full build (`astro check` + build + jampack) passes

## Before merging

Register the event-scoped custom dimension in GA4 (Admin > Data display > Custom definitions): name `Link section`, parameter `link_section`. Registration is not retroactive, so it should exist before this deploys. Leave Enhanced Measurement outbound clicks ON for a week to compare capture rates.