### PR TITLE
Give every page the header's shell, and drop the homepage kicker

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -21,7 +21,12 @@ export default function Card({ href, frontmatter, secHeading = true }: Props) {
   };
 
   return (
-    <li className="my-8">
+    /* A card is title-over-summary — one block of prose, so the whole card
+       takes the measure rather than the shell width its list now spans. Split
+       the other way (long title to 936px, summary clamped to 640) the two
+       stopped reading as one item. The bare-title rows on /posts are the
+       opposite case and do run the full width. */
+    <li className="my-8 max-w-measure">
       <a
         href={href}
         className="inline-block text-skin-base transition-colors hover:text-skin-accent"

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -4,7 +4,13 @@
 
 <!-- mt-16 (collapsing with the last card's mb-8, so 64px) puts real distance
      between the article's own sections and this one, which is page furniture. -->
-<section id="newsletter" class="mb-8 mt-16 p-0">
+<!-- max-w-none/px-0 undo base.css's `section` container from this component's
+     own markup rather than from the page's. The homepage's
+     `#main-content > section` override cannot reach here: Astro scopes that
+     rule to index.astro's elements, and this root section carries this
+     component's scope id, so it kept the centred max-w-3xl and sat indented
+     inside a shell-width page. Inside a post it fills the measure column. -->
+<section id="newsletter" class="mb-8 mt-16 max-w-none px-0">
   <h2 class="section-label">Newsletter</h2>
   <p class="newsletter-intro">
     Sign up to get updates on my latest posts, projects and insights on AI & ML.
@@ -71,10 +77,12 @@
 <style>
   /* Everything here is token-driven — the form used to hardcode five hex values
      (two blues, two greens and a grey) that matched neither theme. */
-  /* Full measure, no 52ch clamp: at this column width the clamp broke two
-     sentences into three short ragged lines under a 28px heading. */
+  /* The measure, no 52ch clamp: the tighter clamp broke two sentences into
+     three short ragged lines under a 28px heading. max-w-measure is a no-op
+     inside a post (that column already is the measure) and does the work on
+     the homepage, where this sits in a shell-width column. */
   .newsletter-intro {
-    @apply mt-4;
+    @apply mt-4 max-w-measure;
     text-wrap: pretty;
   }
   .subscribe-btn {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -75,7 +75,11 @@ export default function SearchBar({ searchList }: Props) {
 
   return (
     <>
-      <label className="relative block">
+      {/* The field keeps the measure inside a shell-width page: it sits
+          directly under a deck clamped to the same 640px, and stretched to the
+          full shell it read as a stray full-bleed element on an otherwise
+          left-anchored column. */}
+      <label className="relative block max-w-measure">
         <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-skin-muted">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -19,7 +19,7 @@ const { frontmatter } = Astro.props;
   <main id="main-content">
     <section
       id="about"
-      class="prose mb-28 max-w-3xl prose-img:border-0"
+      class="prose mx-0 mb-28 max-w-measure px-0 prose-img:border-0"
       data-track="about"
     >
       <h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>
@@ -28,3 +28,14 @@ const { frontmatter } = Astro.props;
   </main>
   <Footer />
 </Layout>
+
+<style>
+  /* The page shell the header, footer and every other page use; the prose
+     inside it keeps the measure. This page had neither — base.css's `section`
+     rule left it at max-w-3xl, which is 95 characters a line, wider than the
+     articles it links to and aligned to nothing else on the site.
+     Typography and copy here are still pre-redesign; only the column moved. */
+  #main-content {
+    @apply mx-auto w-full max-w-shell px-4 pt-8 sm:px-6;
+  }
+</style>

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -50,9 +50,15 @@ const kicker = (props.kicker ?? []).filter(Boolean) as string[];
      sans it outweighed the kicker directly beneath it, and said the same thing
      the kicker and the header's active nav item already say. Pages that need a
      way back up put a post-page-style link in the `backlink` slot. */
+  /* The shell, not the measure: this column holds indexes, chip clouds and card
+     grids, none of which are prose. Held at 40rem they sat 164px inside the
+     header and footer rules that bracket them — the left edge of the text
+     jumped inward the moment you left a post — and the archive wrapped 8 of its
+     18 titles into a 524px slot. The measure still governs everything actually
+     read as prose; it is applied per element (.page-deck here) rather than to
+     the whole page. Padding matches .article-shell so both start at 246px. */
   #main-content {
-    @apply mx-auto w-full px-4 pt-8 pb-4;
-    max-width: theme("maxWidth.measure");
+    @apply mx-auto w-full max-w-shell px-4 pb-4 pt-8 sm:px-6;
   }
   .page-head {
     @apply mb-12;
@@ -77,8 +83,10 @@ const kicker = (props.kicker ?? []).filter(Boolean) as string[];
     margin: 0 0 0.85rem;
     text-wrap: balance;
   }
+  /* Clamped where the shell is not: a deck is prose and reads at the same 81
+     characters an article does. */
   .page-deck {
-    @apply text-skin-muted;
+    @apply max-w-measure text-skin-muted;
     font-size: 1.25rem;
     line-height: 1.5;
     text-wrap: pretty;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -95,12 +95,14 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
 </Layout>
 
 <style>
-  /* The homepage sits at the same measure as an article and the archive. It ran
-     at max-w-3xl, which put summaries near 100 characters a line against the
-     article's 81 — the widest text on the site was the least readable. */
+  /* The page shell is the header's, so the hero starts on the same vertical as
+     the logo above it; the reading measure is applied to the prose inside it
+     (.hero-title, .hero-body, .lead-*) rather than to the page. Holding the
+     whole page at 40rem kept summaries honest but squeezed the row list and the
+     course grid — two 288px cards — into a column sized for one, and left the
+     content floating 172px inside the rules that bracket it. */
   #main-content {
-    @apply mx-auto w-full px-4 pb-4 pt-8;
-    max-width: theme("maxWidth.measure");
+    @apply mx-auto w-full max-w-shell px-4 pb-4 pt-8 sm:px-6;
   }
   /* base.css gives every `section` its own max-width and padding; here the main
      element already owns both, and leaving the section padding on would indent
@@ -116,13 +118,18 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
     letter-spacing: 0.09em;
     text-transform: uppercase;
   }
+  /* Both clamped to the measure inside the wider shell: the headline is written
+     to break after "and", and across the full shell it straightens into one
+     44px line that runs the width of the page. */
   .hero-title {
+    @apply max-w-measure;
     font-size: clamp(2rem, 4.5vw, 2.75rem);
     line-height: 1.08;
     letter-spacing: -0.02em;
     margin: 0 0 1rem;
   }
   .hero-body {
+    @apply max-w-measure;
     font-size: 1.125rem;
     line-height: 1.65;
     text-wrap: pretty;
@@ -147,8 +154,11 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
   .lead {
     @apply block no-underline;
   }
+  /* The lead post is a block of prose — title over summary — so both keep the
+     measure. Left unclamped the summary ran to 120 characters while the rows
+     beneath it stayed short, and the two stopped reading as one section. */
   .lead-title {
-    @apply text-skin-base transition-colors;
+    @apply max-w-measure text-skin-base transition-colors;
     font-size: 1.625rem;
     line-height: 1.2;
     letter-spacing: -0.01em;
@@ -157,7 +167,7 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
     @apply text-skin-accent;
   }
   .lead-deck {
-    @apply mt-2 text-skin-muted;
+    @apply mt-2 max-w-measure text-skin-muted;
     font-size: 1.0625rem;
     line-height: 1.55;
     text-wrap: pretty;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,13 +24,12 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
 <Layout title="Sajal Sharma | AI Engineer | O'Reilly Instructor">
   <Header />
   <main id="main-content">
-    <!-- Hero copy is provisional. The kicker, headline and link labels are
-         settled; the body paragraph is a placeholder Sajal intends to rewrite
-         in the content epic, which will revisit this page. It is factually
-         correct as it stands — no current-employer claim — so it is safe to
-         ship in the meantime, but do not treat it as final wording. -->
+    <!-- Hero copy is provisional. The headline and link labels are settled;
+         the body paragraph is a placeholder Sajal intends to rewrite in the
+         content epic, which will revisit this page. It is factually correct as
+         it stands — no current-employer claim — so it is safe to ship in the
+         meantime, but do not treat it as final wording. -->
     <section id="hero" data-track="home-hero">
-      <p class="hero-kicker">AI Engineer &middot; O'Reilly Instructor</p>
       <h1 class="hero-title">I build AI systems and teach engineers how.</h1>
       <p class="hero-body">
         Eight years shipping machine learning and NLP &mdash; search ranking,
@@ -112,12 +111,6 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
   }
 
   /* ===== Hero ===== */
-  .hero-kicker {
-    @apply mb-4 font-mono text-skin-muted;
-    font-size: 0.8125rem;
-    letter-spacing: 0.09em;
-    text-transform: uppercase;
-  }
   /* Both clamped to the measure inside the wider shell: the headline is written
      to break after "and", and across the full shell it straightens into one
      44px line that runs the width of the page. */

--- a/src/pages/teaching.astro
+++ b/src/pages/teaching.astro
@@ -105,8 +105,10 @@ const courses = coursesByNextSession();
   .teaching-section {
     @apply max-w-none p-0;
   }
+  /* Prose inside a shell-width page keeps the measure; the grids and lists
+     below it take the full width. */
   .section-intro {
-    @apply mt-3 text-skin-muted;
+    @apply mt-3 max-w-measure text-skin-muted;
     font-size: 1rem;
     line-height: 1.6;
     text-wrap: pretty;
@@ -161,7 +163,7 @@ const courses = coursesByNextSession();
     line-height: 1.45;
   }
   .entry-summary {
-    @apply mt-2 text-skin-base;
+    @apply mt-2 max-w-measure text-skin-base;
     font-size: 0.9375rem;
     line-height: 1.5;
   }


### PR DESCRIPTION
Two changes to the homepage and the pages around it.

## Every page gets the header's shell

Every page but the article ran its content column at the reading measure, 40rem. That is right for prose and wrong for everything else those pages hold:

- the archive wrapped 8 of its 18 titles into a 524px slot
- the homepage squeezed a two-card course grid into a column sized for one
- the whole column floated 172px inside the header and footer rules that bracket it, so the left edge of the text jumped inward the moment you left a post

The shell moves out to `max-w-shell`, the width the header and footer already use, and the measure is applied per element to the things actually read as prose: the hero title and body, the lead post's title and deck, the page deck in `Main.astro`, the section intros and entry summaries on `/teaching`, the newsletter intro, and the card in `Card.tsx` — a card is title-over-summary, one block, so the whole card takes the measure rather than splitting a 936px title over a 640px summary. The bare-title rows on `/posts` are the opposite case and do run the full width.

Two riders. The search field takes the measure because it sits directly under a deck clamped to the same 640px; stretched to the full shell it read as a stray full-bleed element on a left-anchored column. And `/about`, which had no shell at all — base.css's `section` rule left it at `max-w-3xl`, 95 characters a line, wider than the articles it links to and aligned to nothing else on the site — now gets the same shell with its prose at the measure. Its typography and copy are still pre-redesign; only the column moved.

## The homepage kicker goes

The hero opened with "AI ENGINEER · O'REILLY INSTRUCTOR" in 13px mono above the headline. Both things it claims are said again in the two elements directly beneath it, in the page's own voice rather than as a label — the headline is "I build AI systems and teach engineers how", and the body closes on "four O'Reilly courses on agents and RAG". A reader got the same two facts three times in the first four lines, and the first of the three was the one written as a job title.

Removing it also gives the headline the top of the page: the largest type on the site at 44px, now starting on the same vertical as the logo above it rather than a line and a half down.

The page `<title>` keeps both terms — that string is what a search result shows, where the headline alone does not say what the site is about.

## Verification

- `astro check` clean, 0 errors
- homepage, `/posts`, `/tags`, `/teaching`, `/about` and a post page all start their content on the same vertical as the header logo
- prose measures unchanged at 81 characters; the course grid holds two cards from 640px up
- hero renders headline-first with no gap left behind; `.hero-kicker` had no other callers and its rule is gone with it