### PR TITLE
Sit the hero on the page's own left edge, and frame the pages that are not articles

### DIFF
--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -50,15 +50,12 @@ const kicker = (props.kicker ?? []).filter(Boolean) as string[];
      sans it outweighed the kicker directly beneath it, and said the same thing
      the kicker and the header's active nav item already say. Pages that need a
      way back up put a post-page-style link in the `backlink` slot. */
-  /* The shell, not the measure: this column holds indexes, chip clouds and card
-     grids, none of which are prose. Held at 40rem they sat 164px inside the
-     header and footer rules that bracket them — the left edge of the text
-     jumped inward the moment you left a post — and the archive wrapped 8 of its
-     18 titles into a 524px slot. The measure still governs everything actually
-     read as prose; it is applied per element (.page-deck here) rather than to
-     the whole page. Padding matches .article-shell so both start at 246px. */
+  /* A centred content frame between the 40rem reading measure and the 61.5rem
+     site shell. Indexes, chip clouds and card grids need more room than prose,
+     but taking the full shell made every non-post page feel pinned beneath the
+     logo. Prose is still clamped per element (.page-deck here). */
   #main-content {
-    @apply mx-auto w-full max-w-shell px-4 pb-4 pt-8 sm:px-6;
+    @apply mx-auto w-full max-w-content px-4 pb-4 pt-8 sm:px-6;
   }
   .page-head {
     @apply mb-12;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,11 +24,17 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
 <Layout title="Sajal Sharma | AI Engineer | O'Reilly Instructor">
   <Header />
   <main id="main-content">
-    <!-- Hero copy is provisional. The headline and link labels are settled;
-         the body paragraph is a placeholder Sajal intends to rewrite in the
-         content epic, which will revisit this page. It is factually correct as
-         it stands — no current-employer claim — so it is safe to ship in the
-         meantime, but do not treat it as final wording. -->
+    <!-- Hero copy is provisional. The headline is settled; the body paragraph
+         is a placeholder Sajal intends to rewrite in the content epic, which
+         will revisit this page. It is factually correct as it stands — no
+         current-employer claim — so it is safe to ship in the meantime, but do
+         not treat it as final wording.
+         The links name the same nouns the header does — writing, courses, me —
+         rather than inventing a second vocabulary for the same destinations.
+         They repeat the nav on purpose: the nav is chrome a reader learns to
+         skip, and this row is the one place the page states plainly where it
+         can take you. Keep them in the nav's own order so the two never
+         disagree about what this site is. -->
     <section id="hero" data-track="home-hero">
       <h1 class="hero-title">I build AI systems and teach engineers how.</h1>
       <p class="hero-body">
@@ -39,8 +45,8 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
         RAG.
       </p>
       <p class="hero-ctas">
-        <a href="/posts">Read my blog</a>
-        <a href="/teaching">Take my courses</a>
+        <a href="/posts">Read my writing</a>
+        <a href="/teaching">View courses</a>
         <a href="/about">About Me</a>
       </p>
     </section>
@@ -50,6 +56,9 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
       {
         lead && (
           <a class="lead" href={`/posts/${lead.id}`}>
+            <time class="lead-date" datetime={toIsoDate(lead.data.pubDatetime)}>
+              {formatPostDate(lead.data.pubDatetime)}
+            </time>
             <h3 class="lead-title">{lead.data.title}</h3>
             <p class="lead-deck">{lead.data.description}</p>
           </a>
@@ -83,7 +92,7 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
         {coursesByNextSession().map(course => <CourseCard course={course} />)}
       </ul>
       <p class="more" data-track="home-all-teaching">
-        <a href="/teaching">All teaching &rarr;</a>
+        <a href="/teaching">All courses &rarr;</a>
       </p>
     </section>
 
@@ -94,14 +103,19 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
 </Layout>
 
 <style>
-  /* The page shell is the header's, so the hero starts on the same vertical as
-     the logo above it; the reading measure is applied to the prose inside it
-     (.hero-title, .hero-body, .lead-*) rather than to the page. Holding the
-     whole page at 40rem kept summaries honest but squeezed the row list and the
-     course grid — two 288px cards — into a column sized for one, and left the
-     content floating 172px inside the rules that bracket it. */
+  /* The content frame sits between the reading measure and the header shell:
+     wide enough for archive rows and two real card columns, but centred so the
+     homepage does not feel pinned beneath the logo. It is 44px inside the
+     header and footer rules at each end, which is deliberate — the rules
+     bracket the page, the frame holds it.
+     The top padding is this page's own: 48px on desktop against the 32px every
+     other page opens with. The rule below the header is the same everywhere but
+     what sits under it is not — a list page puts a 36px title there and a post
+     a 14px backlink, while this page puts 44px display type straight against
+     it. Mobile stays at 32: the headline is 32px there and no longer crowds the
+     rule, and above the fold on a phone is the scarcest space on the site. */
   #main-content {
-    @apply mx-auto w-full max-w-shell px-4 pb-4 pt-8 sm:px-6;
+    @apply mx-auto w-full max-w-content px-4 pb-4 pt-8 sm:px-6 sm:pt-12;
   }
   /* base.css gives every `section` its own max-width and padding; here the main
      element already owns both, and leaving the section padding on would indent
@@ -111,9 +125,25 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
   }
 
   /* ===== Hero ===== */
-  /* Both clamped to the measure inside the wider shell: the headline is written
-     to break after "and", and across the full shell it straightens into one
-     44px line that runs the width of the page. */
+  /* The hero keeps the reading measure but starts on the frame's own left edge
+     rather than centring inside it. Centred, it was a third left edge — the
+     header rule at one x, the sections at another, the headline at a third —
+     and the offset was not even a constant to learn: it is
+     (min(vw, 896) - 48 - 640) / 2, so it slid from 0 to 104px as the window
+     grew between roughly 700 and 900px, and the headline visibly drifted
+     sideways against the list beneath it. The measure stays on the section, not
+     just on .hero-title and .hero-body, so the link row wraps on the same
+     column the prose does.
+     mx-0 is load-bearing, not decoration: base.css's global
+     `section, footer { mx-auto max-w-3xl px-4 }` still applies here, and the
+     `#main-content > section` reset above gives back the max-width and the
+     padding but not the auto margins. Every other section is max-w-none, so
+     auto margins resolve to 0 and the rule is invisible; the hero is the one
+     section narrower than its container, so dropping `mx-auto` from this block
+     left it centred anyway by a rule declared in another file. */
+  #main-content > #hero {
+    @apply mx-0 max-w-measure;
+  }
   .hero-title {
     @apply max-w-measure;
     font-size: clamp(2rem, 4.5vw, 2.75rem);
@@ -144,8 +174,30 @@ const rows = sorted.filter(post => post.id !== lead?.id).slice(0, 4);
   }
 
   /* ===== Writing ===== */
+  /* The first section boundary is wider than the rest. 3.2rem is the site's
+     section constant and every other boundary keeps it, including #teaching
+     below — but this one separates the page's opening statement from its
+     contents rather than one list from the next, and at the constant the hero
+     read as the first item in the Writing section instead of as the thing the
+     sections hang under. Scoped to #writing alone so the stack below the hero
+     stays evenly spaced. */
+  #writing > .section-heading {
+    margin-top: 4.25rem;
+  }
   .lead {
     @apply block no-underline;
+  }
+  /* The lead was the only undated post on the site, sitting directly above four
+     dated rows. It is chosen as the newest *featured* post while the rows are
+     taken by date, so publishing a single unfeatured piece is enough to put a
+     newer date under an older headline with nothing on screen to explain it —
+     the same way an ungrouped list read as though its sort was broken, which is
+     why the rows below carry the year. Muted, and outside .lead:hover's
+     recolour, so it reads as chronology rather than as part of the link. */
+  .lead-date {
+    @apply mb-2 block font-mono text-skin-muted;
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
   }
   /* The lead post is a block of prose — title over summary — so both keep the
      measure. Left unclamped the summary ran to 120 characters while the rows

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -33,6 +33,10 @@ module.exports = {
         // raises the browser's default font size: with a px measure beside rem
         // gaps, a 24px root pushed the rail 58px past the viewport.
         measure: "40rem",
+        // Non-article page content: wide enough for archive rows and two useful
+        // card columns, but narrower than the article/header shell so the page
+        // does not feel anchored to the left edge of that wider frame.
+        content: "56rem",
         // The page shell: measure (40) + gap (4.5) + TOC rail (14) + padding (3).
         // The header and footer use it too, so their rules line up with the
         // article's outer edges.


### PR DESCRIPTION
The homepage read as an hourglass: wide header rule, narrow centred hero, medium content column, wide footer rule. This straightens it, and lands the content frame the other non-article pages were already using in the working tree.

## The diagnosis

Measured at 1280px, the page presented **three left edges at once**:

```
header rule    166 ————————————————————————— 1102   (936 wide)
sections       210 ——————————————————— 1058          (848)
HERO               314 ————————— 954                 (640)   <- the waist
sections       210 ——————————————————— 1058          (848)
footer rule    166 ————————————————————————— 1102   (936)
```

The hero's offset was not even a constant to learn — it is `(min(vw, 896) - 48 - 640) / 2`, so it slid from 0 to 104px as the window grew between roughly 700 and 900px, and the headline drifted sideways against the list beneath it while you resized. An 11px or 26px offset does not read as design; it reads as a rounding error.

The vertical half had the same cause. Gaps ran 32 (header rule → hero) < 51.2 (every section boundary) < 64 (newsletter): the 44px headline, the largest type on the site, got the smallest gap on the page and less above it than below its own link row. A post title starts ~84px below that same rule. The hero had been given horizontal space to compensate for vertical space it was not given.

## What changed

**The frame** (`tailwind.config.cjs`, `Main.astro`) — a third width between the 40rem measure and the 61.5rem shell. 56rem is wide enough for archive rows and two real card columns without pinning the page beneath the logo. Prose stays clamped per element, never by the frame.

**The hero** (`index.astro`) — keeps the reading measure, starts where the sections start. `mx-0` is load-bearing: base.css's global `section, footer { mx-auto max-w-3xl px-4 }` still reaches this element, and the `#main-content > section` reset gives back the max-width and padding but not the auto margins. Every other section is `max-w-none`, so auto margins resolve to 0 and the global is invisible — the hero is the one section narrower than its container, so dropping `mx-auto` left it centred anyway by a rule in another file.

Alongside it, on this page only:

- **48px above the hero** on desktop against the 32px every other page opens with. The rule under the header is the same everywhere; what sits beneath it is not. Mobile stays at 32.
- **The first section boundary widens to 68px.** Every other boundary keeps the 3.2rem constant, `#teaching` included — this one separates the page's opening statement from its contents rather than one list from the next.
- **The lead post gets its date.** It was the only undated post on the site, sitting above four dated rows, and it is chosen as the newest *featured* post while the rows are taken by date — so one unfeatured post is enough to put a newer date under an older headline.
- **Link labels** name the same nouns the header does instead of a second vocabulary for the same destinations; the teaching section ends in "All courses".

## Result

| | before | after |
|---|---|---|
| Distinct left edges | 3 | **2** (rule, then content + hero) |
| Header rule → hero | 32 | **48** desktop / 32 mobile |
| Hero → Writing | 51.2 | **68** |
| Writing → Teaching | 51.2 | 51.2 (unchanged) |
| Lead post | undated, 26px | dated, 26px |

The two remaining edges are the rules bracketing the page and the frame holding it — deliberate, and constant at every width.

## Verification

- `astro check`: 0 errors, 0 warnings. Prettier clean. The 3 ESLint errors in `Layout.astro` are pre-existing GA4 globals, untouched here.
- Geometry measured against the running dev server at 320, 390, 960, 1280, 1440 and 1495px — no horizontal overflow at any of them, both themes.
- `/teaching` still reports 51.2px on all three section headings and 32px top padding, confirming the `#writing` override and the new `.lead-date` stay scoped to the homepage.
- Hero links sit on one row down to 390px (an improvement — the old labels orphaned the third at 390). At 320px the row wraps to two; the three labels' ink alone is 294px against 288px of column, so no `gap-x` value fits them and wrapping is correct there.

## Not in this PR

Two findings from the same review, both independent of this change:

- `sm: "640px"` is the only px value in a rem-based system. At a 24px browser root the media query still fires at 640 while the nav needs 783px, giving **83px of horizontal scroll with the hamburger already hidden**, on every route from 640–782px. Reproduced in Chrome. `sm: "40rem"` is byte-identical at the default root.
- The global `section, footer { max-w-3xl px-4 }` in base.css has zero beneficiaries — all 15 elements override it — and has now caused two bugs, including the `mx-auto` trap above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)