### PR TITLE
Redirect the folded tags and pin the vendored katex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,15 @@ stamp records which release was vendored, not that the bytes are still there,
 and a missing stylesheet would ship a post with unstyled math. Re-vendor with
 `npm run katex:vendor`.
 
+`katex` is a direct dependency pinned to an **exact** version, even though only
+`rehype-katex` imports it. Both properties are load-bearing: as a transitive
+dependency its version was set by `rehype-katex`'s own semver range, so any
+lockfile refresh could move it, and a caret range here would do the same on a
+fresh install. Either way `katex:check` fails the next build — including the
+unattended nightly one — with nothing in `package.json` to explain why. Bumping
+the pin is therefore a two-step change: raise the version, then
+`npm run katex:vendor` and commit the new bytes.
+
 ### OG Image Generation
 The `/og.png.ts` endpoint dynamically generates Open Graph images. Custom templates live in `src/utils/og-templates/`.
 
@@ -188,6 +197,8 @@ Both reuse `getSortedPosts`/`postFilter` (no draft/scheduled leakage) and share 
 - Sitemap auto-generated via `@astrojs/sitemap`
 - robots.txt dynamically generated in `src/pages/robots.txt.ts`
 - Canonical URLs supported via frontmatter
+- Internal links carry the trailing slash (`/posts/`, `/search/`, `/tags/rag/`). The build emits `index.html` per directory and the sitemap lists the slashed form, so a slashless link costs a GitHub Pages 301
+- **Retiring a URL means adding a redirect** in `astro.config.ts`. Anything the build has published is in the sitemap and gets indexed, so a removed page, a renamed slug, a changed `postPerPage`, or a folded tag turns live search results into 404s. The block there covers a legacy pre-Astro URL, a slug typo, the removed backprop page, the pagination URLs the redesign retired, and the 19 tags the taxonomy fold removed — each pointing at the tag that absorbed its posts. Dynamic redirects (`/tags/[tag]/1`) are enumerated from the destination route's `getStaticPaths`, so they only ever cover URLs that still exist; a retired one needs its own literal entry
 
 ## Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,15 @@ stamp records which release was vendored, not that the bytes are still there,
 and a missing stylesheet would ship a post with unstyled math. Re-vendor with
 `npm run katex:vendor`.
 
+`katex` is a direct dependency pinned to an **exact** version, even though only
+`rehype-katex` imports it. Both properties are load-bearing: as a transitive
+dependency its version was set by `rehype-katex`'s own semver range, so any
+lockfile refresh could move it, and a caret range here would do the same on a
+fresh install. Either way `katex:check` fails the next build — including the
+unattended nightly one — with nothing in `package.json` to explain why. Bumping
+the pin is therefore a two-step change: raise the version, then
+`npm run katex:vendor` and commit the new bytes.
+
 ### OG Image Generation
 The `/og.png.ts` endpoint dynamically generates Open Graph images. Custom templates live in `src/utils/og-templates/`.
 
@@ -188,6 +197,8 @@ Both reuse `getSortedPosts`/`postFilter` (no draft/scheduled leakage) and share 
 - Sitemap auto-generated via `@astrojs/sitemap`
 - robots.txt dynamically generated in `src/pages/robots.txt.ts`
 - Canonical URLs supported via frontmatter
+- Internal links carry the trailing slash (`/posts/`, `/search/`, `/tags/rag/`). The build emits `index.html` per directory and the sitemap lists the slashed form, so a slashless link costs a GitHub Pages 301
+- **Retiring a URL means adding a redirect** in `astro.config.ts`. Anything the build has published is in the sitemap and gets indexed, so a removed page, a renamed slug, a changed `postPerPage`, or a folded tag turns live search results into 404s. The block there covers a legacy pre-Astro URL, a slug typo, the removed backprop page, the pagination URLs the redesign retired, and the 19 tags the taxonomy fold removed — each pointing at the tag that absorbed its posts. Dynamic redirects (`/tags/[tag]/1`) are enumerated from the destination route's `getStaticPaths`, so they only ever cover URLs that still exist; a retired one needs its own literal entry
 
 ## Development Workflow
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -47,6 +47,58 @@ export default defineConfig({
     "/tags/llms/2": "/tags/llms/",
     "/tags/ai-agents/2": "/tags/ai-agents/",
     "/tags/langgraph/2": "/tags/langgraph/",
+    // Tags the content pass folded away, 31 down to 12. Same argument as the
+    // pagination URLs above: every one of these was built from the frontmatter,
+    // listed in main's sitemap and indexed, so without a rule here they 404 for
+    // anyone holding a search result. Each points at the tag that actually
+    // absorbed its posts, taken from the frontmatter diff rather than chosen by
+    // feel — `agentic-workflows -> ai-agents` and `aws -> machine-learning` were
+    // literal substitutions in the posts that carried them. Tag URL to tag URL,
+    // so the destination still lists the post the reader was looking for.
+    //
+    // The `/1` twin of each is spelled out rather than left to the
+    // `/tags/[tag]/1` rule above: that one is a dynamic redirect, so Astro
+    // enumerates it from the destination route's getStaticPaths and it covers
+    // only the twelve tags that still exist. None of these had a `/2` — the
+    // largest ran to four posts against the old five-per-page setting.
+    "/tags/agentic-workflows": "/tags/ai-agents/",
+    "/tags/agentic-workflows/1": "/tags/ai-agents/",
+    "/tags/ai-integration": "/tags/ai-engineering/",
+    "/tags/ai-integration/1": "/tags/ai-engineering/",
+    "/tags/ai-tools": "/tags/ai-coding/",
+    "/tags/ai-tools/1": "/tags/ai-coding/",
+    "/tags/automation": "/tags/ai-agents/",
+    "/tags/automation/1": "/tags/ai-agents/",
+    "/tags/aws": "/tags/machine-learning/",
+    "/tags/aws/1": "/tags/machine-learning/",
+    "/tags/claude-code": "/tags/ai-coding/",
+    "/tags/claude-code/1": "/tags/ai-coding/",
+    "/tags/computer-vision": "/tags/machine-learning/",
+    "/tags/computer-vision/1": "/tags/machine-learning/",
+    "/tags/fastai": "/tags/machine-learning/",
+    "/tags/fastai/1": "/tags/machine-learning/",
+    "/tags/generative-ai": "/tags/llms/",
+    "/tags/generative-ai/1": "/tags/llms/",
+    "/tags/interviews": "/tags/career/",
+    "/tags/interviews/1": "/tags/career/",
+    "/tags/machine-learning-from-scratch": "/tags/machine-learning/",
+    "/tags/machine-learning-from-scratch/1": "/tags/machine-learning/",
+    "/tags/mcp": "/tags/ai-engineering/",
+    "/tags/mcp/1": "/tags/ai-engineering/",
+    "/tags/online-learning": "/tags/teaching/",
+    "/tags/online-learning/1": "/tags/teaching/",
+    "/tags/productivity": "/tags/ai-coding/",
+    "/tags/productivity/1": "/tags/ai-coding/",
+    "/tags/reflections": "/tags/career/",
+    "/tags/reflections/1": "/tags/career/",
+    "/tags/sandboxing": "/tags/ai-agents/",
+    "/tags/sandboxing/1": "/tags/ai-agents/",
+    "/tags/software-architecture": "/tags/ai-engineering/",
+    "/tags/software-architecture/1": "/tags/ai-engineering/",
+    "/tags/software-development": "/tags/ai-coding/",
+    "/tags/software-development/1": "/tags/ai-coding/",
+    "/tags/ventures": "/tags/product/",
+    "/tags/ventures/1": "/tags/product/",
   },
   integrations: [react(), sitemap()],
   markdown: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "astro": "^7.0.7",
         "fuse.js": "^7.0.0",
         "github-slugger": "^2.0.0",
+        "katex": "0.16.47",
         "rehype-katex": "^7.0.0",
         "remark-collapse": "^0.1.2",
         "remark-math": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "astro": "^7.0.7",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
+    "katex": "0.16.47",
     "rehype-katex": "^7.0.0",
     "remark-collapse": "^0.1.2",
     "remark-math": "^6.0.0",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -89,8 +89,11 @@ const NAV_ITEMS = [
                  descendant rule: LinkButton's anchor is another component's
                  root, so it never receives this component's scope attribute and
                  such a rule silently matches nothing. -->
+            <!-- Trailing slash, like every NAV_ITEMS href: the build emits
+                 /search/ and the sitemap lists it, so the slashless form takes
+                 a GitHub Pages 301 on the way. This link is on all 38 pages. -->
             <LinkButton
-              href="/search"
+              href="/search/"
               className={`focus-outline flex p-3 transition-colors sm:p-1 ${
                 activeNav === "search"
                   ? "text-skin-base"

--- a/src/layouts/TagPosts.astro
+++ b/src/layouts/TagPosts.astro
@@ -57,13 +57,18 @@ const { currentPage, totalPages, paginatedPosts, totalPosts, tag, tagName } =
     }
   </style>
 
+  <!-- Both ends carry the trailing slash the rest of the site's internal links
+       do. Stepping back to page 1 lands on the bare tag URL, which is where
+       page 1 lives; `/tags/foo` without the slash would take a GitHub Pages 301
+       to get there. Nothing paginates at the current 20-per-page setting, so
+       this is arithmetic being kept correct for whenever something does. -->
   <Pagination
     {currentPage}
     {totalPages}
-    prevUrl={`/tags/${tag}${
-      currentPage - 1 !== 1 ? "/" + (currentPage - 1) : ""
+    prevUrl={`/tags/${tag}/${
+      currentPage - 1 !== 1 ? currentPage - 1 + "/" : ""
     }`}
-    nextUrl={`/tags/${tag}/${currentPage + 1}`}
+    nextUrl={`/tags/${tag}/${currentPage + 1}/`}
   />
 
   <Footer noMarginTop={totalPages > 1} />


### PR DESCRIPTION
Four defects found reviewing #89 against `main`.

## Retired tag URLs 404'd

The content pass folded the taxonomy from 31 tags to 12. Every one of the 31 was built from the frontmatter, listed in `main`'s sitemap and indexed, so the 19 that went away would have 404'd for anyone holding a search result. #89 already made this argument for the pagination URLs it retired; the same argument applies here and was missed.

Each retired tag now redirects to the tag that actually absorbed its posts, read off the frontmatter diff rather than chosen by feel — `agentic-workflows -> ai-agents` and `aws -> machine-learning` were literal substitutions in the posts that carried them:

| retired | → | retired | → |
|---|---|---|---|
| `agentic-workflows`, `automation`, `sandboxing` | `ai-agents` | `interviews`, `reflections` | `career` |
| `ai-tools`, `claude-code`, `productivity`, `software-development` | `ai-coding` | `generative-ai` | `llms` |
| `ai-integration`, `mcp`, `software-architecture` | `ai-engineering` | `online-learning` | `teaching` |
| `aws`, `computer-vision`, `fastai`, `machine-learning-from-scratch` | `machine-learning` | `ventures` | `product` |

Tag URL to tag URL, so the destination still lists the post the reader came for.

The `/1` twin of each is spelled out rather than left to the existing `/tags/[tag]/1` rule: that one is a dynamic redirect, so Astro enumerates it from the destination route's `getStaticPaths` and it covers only the twelve tags that still exist. None of the retired tags had a `/2` — the largest ran to four posts against the old five-per-page setting.

## `katex:check` gated the build on an undeclared dependency

`katex` was never in `package.json` — only `rehype-katex ^7.0.0` pulled it in — yet `scripts/vendor-katex.mjs check` byte-compares `public/katex` against the resolved package and `process.exit(1)`s on a mismatch, inside `npm run build`. Any lockfile refresh (`npm update`, `npm audit fix`, Dependabot, or simply adding a package) could move it to 0.16.48 and fail every build until someone ran `npm run katex:vendor`, with nothing in `package.json` to explain why — and #89 added a nightly cron, so it would have fired unattended.

Pinned exact as a direct dependency, which is what the vendor script's own docstring already claimed was true. Bumping it is now a deliberate two-step change, documented in CLAUDE.md.

## Two non-canonical internal links

The header's search link was `/search` — the one internal URL on the site without a trailing slash, on all 38 pages, taking a GitHub Pages 301 on every click while the sitemap advertised `/search/`. Tag pagination's `prevUrl` had the same gap; unreachable at 20 posts per page, wrong whenever a tag grows past it.

## Verification

Full `npm run build` (`katex:check` → `astro check` → `astro build` → `jampack`):

- 38/38 redirect pages resolve to the intended successor
- all 12 surviving tag pages still render normally, unshadowed by the new rules
- **zero** non-canonical internal links across the built site (was: `/search` on 38 pages)
- **zero** broken internal links
- sitemap unchanged at 37 URLs, no redirect stubs leaked in