### PR TITLE
tweak(writing): drop the archive kicker from the writing page

### DIFF
--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -43,7 +43,7 @@ const years = Object.keys(byYear)
   description="Writing by Sajal Sharma on AI engineering, agents, retrieval systems, AI products, and the decisions involved in building them."
 >
   <Header activeNav="posts" />
-  <Main pageTitle="Writing" kicker={["Archive", `${posts.length} posts`]}>
+  <Main pageTitle="Writing">
     <div data-track="posts-list">
       {
         years.map(year => (


### PR DESCRIPTION
## What

Removes the `ARCHIVE · N POSTS` kicker line from the Writing page (`/posts/`), so the header goes straight to the "Writing" title.

## Why

"Archive" carries a connotation of dormant, put-away material — which sits oddly against a page whose job is to be the living index of an actively-written blog. It was also the only reader-facing "Archive" on the site.

No replacement label fit cleanly:
- **Index** already belongs to the Tags page
- **Writing** is the H1 directly below
- **All posts** would double the count (`ALL POSTS · N POSTS`)

So the header now simply drops the kicker rather than swapping in a weaker word. The `<head>` description that carries the page's summary for search results and link previews is untouched.

## Change

One line in `src/pages/posts/index.astro`: dropped the optional `kicker` prop from the `<Main>` call.

## Verification

Confirmed on the dev server at `/posts/` — the label is gone and the year-grouped list renders unchanged.